### PR TITLE
refactor: change PotG -> Pot

### DIFF
--- a/lib/app/modules/common/presentation/widgets/pot_app_bar.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_app_bar.dart
@@ -1,11 +1,11 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:pot_g/app/modules/common/presentation/widgets/pot_g_icon_button.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_icon_button.dart';
 import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/gen/assets.gen.dart';
 
-class PotGAppBar extends StatelessWidget implements PreferredSizeWidget {
-  const PotGAppBar({
+class PotAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const PotAppBar({
     super.key,
     this.actions = const [],
     this.title,
@@ -56,7 +56,7 @@ class PotGAppBar extends StatelessWidget implements PreferredSizeWidget {
                     ? leadingType == LeadingType.back
                         ? Padding(
                           padding: const EdgeInsets.only(left: 16),
-                          child: PotGIconButton(
+                          child: PotIconButton(
                             icon: Assets.icons.arrowLeft.svg(),
                             onPressed: action,
                           ),

--- a/lib/app/modules/common/presentation/widgets/pot_button.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_button.dart
@@ -2,33 +2,33 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pot_g/app/values/palette.dart';
 
-enum PotGButtonVariant { emphasized, outlined }
+enum PotButtonVariant { emphasized, outlined }
 
-enum PotGButtonSize { small, medium, large }
+enum PotButtonSize { small, medium, large }
 
-class PotGButton extends StatefulWidget {
-  const PotGButton({
+class PotButton extends StatefulWidget {
+  const PotButton({
     super.key,
     this.padding,
     this.child,
     this.onPressed,
     this.variant,
-    this.size = PotGButtonSize.large,
+    this.size = PotButtonSize.large,
     this.prefixIcon,
   });
 
   final EdgeInsetsGeometry? padding;
   final Widget? child;
   final VoidCallback? onPressed;
-  final PotGButtonVariant? variant;
-  final PotGButtonSize size;
+  final PotButtonVariant? variant;
+  final PotButtonSize size;
   final Widget? prefixIcon;
 
   @override
-  State<PotGButton> createState() => _PotGButtonState();
+  State<PotButton> createState() => _PotButtonState();
 }
 
-class _PotGButtonState extends State<PotGButton> {
+class _PotButtonState extends State<PotButton> {
   bool _pressed = false;
   bool _active = false;
   bool get pressed => _pressed || _active;
@@ -86,10 +86,10 @@ class _PotGButtonState extends State<PotGButton> {
 
   BorderRadiusGeometry _getBorderRadius() {
     switch (widget.size) {
-      case PotGButtonSize.large:
-      case PotGButtonSize.medium:
+      case PotButtonSize.large:
+      case PotButtonSize.medium:
         return BorderRadius.all(Radius.circular(10));
-      case PotGButtonSize.small:
+      case PotButtonSize.small:
         return BorderRadius.all(Radius.circular(5));
     }
   }
@@ -97,7 +97,7 @@ class _PotGButtonState extends State<PotGButton> {
   BoxBorder? _getBorder() {
     if (widget.onPressed == null) return null;
     switch (widget.variant) {
-      case PotGButtonVariant.outlined:
+      case PotButtonVariant.outlined:
         return Border.all(color: Palette.primary, width: 1.5);
       case null:
         return Border.all(color: Palette.borderGrey, width: 1.5);
@@ -108,11 +108,11 @@ class _PotGButtonState extends State<PotGButton> {
 
   EdgeInsetsGeometry _getPadding() {
     switch (widget.size) {
-      case PotGButtonSize.large:
+      case PotButtonSize.large:
         return const EdgeInsets.symmetric(horizontal: 20, vertical: 15);
-      case PotGButtonSize.medium:
+      case PotButtonSize.medium:
         return const EdgeInsets.symmetric(horizontal: 25, vertical: 10);
-      case PotGButtonSize.small:
+      case PotButtonSize.small:
         return const EdgeInsets.symmetric(horizontal: 15, vertical: 7);
     }
   }
@@ -120,10 +120,10 @@ class _PotGButtonState extends State<PotGButton> {
   Color _getBackgroundColor() {
     if (widget.onPressed == null) return Palette.borderGrey;
     switch (widget.variant) {
-      case PotGButtonVariant.emphasized:
+      case PotButtonVariant.emphasized:
         if (pressed) return const Color(0xff346405);
         return Palette.primary;
-      case PotGButtonVariant.outlined:
+      case PotButtonVariant.outlined:
         if (pressed) return Palette.primaryLight;
         return Palette.white;
       default:
@@ -134,7 +134,7 @@ class _PotGButtonState extends State<PotGButton> {
 
   FontWeight _getFontWeight() {
     switch (widget.size) {
-      case PotGButtonSize.large:
+      case PotButtonSize.large:
         return FontWeight.w700;
       default:
         return FontWeight.w600;
@@ -144,9 +144,9 @@ class _PotGButtonState extends State<PotGButton> {
   Color _getTextColor() {
     if (widget.onPressed == null) return Palette.grey;
     switch (widget.variant) {
-      case PotGButtonVariant.emphasized:
+      case PotButtonVariant.emphasized:
         return Palette.primaryLight;
-      case PotGButtonVariant.outlined:
+      case PotButtonVariant.outlined:
         return Palette.primary;
       default:
         return Palette.textGrey;
@@ -155,7 +155,7 @@ class _PotGButtonState extends State<PotGButton> {
 
   double _getFontSize() {
     switch (widget.size) {
-      case PotGButtonSize.large:
+      case PotButtonSize.large:
         return 20;
       default:
         return 18;
@@ -164,7 +164,7 @@ class _PotGButtonState extends State<PotGButton> {
 
   double _getIconGap() {
     switch (widget.size) {
-      case PotGButtonSize.large:
+      case PotButtonSize.large:
         return 8;
       default:
         return 4;

--- a/lib/app/modules/common/presentation/widgets/pot_icon_button.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_icon_button.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class PotGIconButton extends StatelessWidget {
-  const PotGIconButton({
+class PotIconButton extends StatelessWidget {
+  const PotIconButton({
     super.key,
     required this.icon,
     required this.onPressed,

--- a/lib/app/modules/common/presentation/widgets/pot_toggle.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_toggle.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pot_g/app/values/palette.dart';
 
-class PotGToggle extends StatelessWidget {
-  const PotGToggle({
+class PotToggle extends StatelessWidget {
+  const PotToggle({
     super.key,
     required this.value,
     required this.onChanged,

--- a/lib/app/modules/main/presentation/pages/main_page.dart
+++ b/lib/app/modules/main/presentation/pages/main_page.dart
@@ -1,9 +1,9 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
-import 'package:pot_g/app/modules/common/presentation/widgets/pot_g_app_bar.dart';
-import 'package:pot_g/app/modules/common/presentation/widgets/pot_g_button.dart';
-import 'package:pot_g/app/modules/common/presentation/widgets/pot_g_icon_button.dart';
-import 'package:pot_g/app/modules/common/presentation/widgets/pot_g_toggle.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_button.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_icon_button.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_toggle.dart';
 import 'package:pot_g/gen/assets.gen.dart';
 
 @RoutePage()
@@ -19,24 +19,24 @@ class _MainPageState extends State<MainPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: PotGAppBar(
+      appBar: PotAppBar(
         title: Text('내 정보'),
         actions: [
-          PotGIconButton(icon: Assets.icons.addPot.svg(), onPressed: () {}),
-          PotGIconButton(icon: Assets.icons.userCircle.svg(), onPressed: () {}),
+          PotIconButton(icon: Assets.icons.addPot.svg(), onPressed: () {}),
+          PotIconButton(icon: Assets.icons.userCircle.svg(), onPressed: () {}),
         ],
       ),
       body: Column(
         children: [
           Text('title'),
           const SizedBox(height: 20),
-          PotGButton(
+          PotButton(
             onPressed: () {},
-            variant: PotGButtonVariant.emphasized,
+            variant: PotButtonVariant.emphasized,
             child: Text('button'),
           ),
           const SizedBox(height: 20),
-          PotGToggle(
+          PotToggle(
             value: _isEnabled,
             onChanged: (value) {
               setState(() => _isEnabled = value);

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -8,8 +8,8 @@ import 'package:pot_g/gen/strings.g.dart';
 
 final _appRouter = AppRouter();
 
-class PotGApp extends StatelessWidget {
-  const PotGApp({super.key});
+class PotApp extends StatelessWidget {
+  const PotApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +18,7 @@ class PotGApp extends StatelessWidget {
       child: GestureDetector(
         onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
         child: MaterialApp.router(
-          theme: PotGTheme.theme,
+          theme: PotTheme.theme,
           routerConfig: _appRouter.config(),
           locale: TranslationProvider.of(context).flutterLocale,
           supportedLocales: AppLocaleUtils.supportedLocales,

--- a/lib/app/values/theme.dart
+++ b/lib/app/values/theme.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:pot_g/app/values/fonts.dart';
 import 'package:pot_g/app/values/palette.dart';
 
-abstract class PotGTheme {
+abstract class PotTheme {
   static final theme = ThemeData(
     fontFamily: Pretendard.fontFamily,
     scaffoldBackgroundColor: Palette.white,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:pot_g/app/pot_g_app.dart';
+import 'package:pot_g/app/pot_app.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
 void main() {
-  runApp(TranslationProvider(child: const PotGApp()));
+  runApp(TranslationProvider(child: const PotApp()));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 내부 UI 컴포넌트(앱 바, 버튼, 아이콘 버튼, 토글 등)의 명칭을 일관되게 재정비하여 유지보수성을 개선하였습니다.
	- 앱 진입점과 테마 설정 관련 클래스의 명칭을 표준화하여 코드 구조를 정리하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->