### PR TITLE
fix: don't delete token after expired internally

### DIFF
--- a/lib/app/modules/auth/data/repositories/oauth_auth_repository.dart
+++ b/lib/app/modules/auth/data/repositories/oauth_auth_repository.dart
@@ -51,11 +51,6 @@ class OauthAuthRepository implements AuthRepository {
   Stream<UserEntity?> get user =>
       _tokenRepository.token.asyncMap((token) async {
         if (token == null) return null;
-        final exp = _tokenRepository.tokenExpiration;
-        if (exp != null && exp.isBefore(DateTime.now())) {
-          await _tokenRepository.deleteToken();
-          return null;
-        }
         try {
           return _parseUser(token);
         } catch (e) {

--- a/lib/app/modules/auth/domain/entity/token_entity.dart
+++ b/lib/app/modules/auth/domain/entity/token_entity.dart
@@ -8,4 +8,9 @@ class TokenEntity {
     required this.refreshToken,
     required this.idToken,
   });
+
+  @override
+  String toString() {
+    return 'TokenEntity(accessToken: $accessToken, refreshToken: $refreshToken, idToken: $idToken)';
+  }
 }

--- a/lib/app/modules/auth/domain/entity/token_entity.dart
+++ b/lib/app/modules/auth/domain/entity/token_entity.dart
@@ -8,9 +8,4 @@ class TokenEntity {
     required this.refreshToken,
     required this.idToken,
   });
-
-  @override
-  String toString() {
-    return 'TokenEntity(accessToken: $accessToken, refreshToken: $refreshToken, idToken: $idToken)';
-  }
 }


### PR DESCRIPTION
instead rely on refresh logic in dio interrupt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 만료된 토큰으로 인해 로그아웃되는 현상이 더 이상 발생하지 않습니다.

- **신규 기능**
  - 토큰 정보의 문자열 표현이 개선되어, 토큰 객체를 보다 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->