### PR TITLE
fix(ci/cd): ssh key action - known_hosts option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Changed Files (android)
-        uses: tj-actions/changed-files@v37.5.0
+        uses: tj-actions/changed-files@v46
         id: android-changed-files
         with:
           files: |
@@ -29,7 +28,7 @@ jobs:
             lib/**
 
       - name: Changed Files (iOS)
-        uses: tj-actions/changed-files@v37.5.0
+        uses: tj-actions/changed-files@v46
         id: ios-changed-files
         with:
           files: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Changed Files (android)

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -31,6 +31,7 @@ jobs:
         if: matrix.os == 'iOS'
         with:
           key: ${{ secrets.CERTIFICATION_DEPLOY_KEY }}
+          known_hosts: unnecessary
 
       - name: Write Keystore
         if: matrix.os == 'Android'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Chores**
  * iOS 빌드 매트릭스의 GitHub Actions 워크플로우 설정이 업데이트되었습니다.
  * 풀 리퀘스트의 올바른 저장소에서 코드를 체크아웃하도록 GitHub Actions 워크플로우가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->