### PR TITLE
chore(ci/cd): disable android internal app

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -53,14 +53,15 @@ platform :android do
       skip_upload_images: true,
       skip_upload_screenshots: true,
     )
-    internal_app_url = upload_to_play_store_internal_app_sharing(
-      aab: "../build/app/outputs/bundle/release/app-release.aab",
-    )
+    # TODO: uncomment this when ready
+    # internal_app_url = upload_to_play_store_internal_app_sharing(
+    #   aab: "../build/app/outputs/bundle/release/app-release.aab",
+    # )
     slack(
       payload: {
         "Build Date" => Time.now.to_s,
         "Build Number" => build_number,
-        "Internal App" => "<#{internal_app_url}>",
+        # "Internal App" => "<#{internal_app_url}>",
       }
     ) if ENV['CI']
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 내부 앱 공유 업로드 단계와 해당 URL이 포함된 Slack 메시지 전송이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->