### PR TITLE
fix(ci/cd): ignore crashlytics upload error

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -33,7 +33,11 @@ platform :android do
       "--build-number=#{build_number}",
     )
 
-    sh("firebase", "crashlytics:symbols:upload", "--app=#{android_app_id}", "../../#{debug_info_path}")
+    begin
+      sh("firebase", "crashlytics:symbols:upload", "--app=#{android_app_id}", "../../#{debug_info_path}")
+    rescue => e
+      UI.message("Ignoring error during Crashlytics symbols upload: #{e.message}")
+    end
 
     symbols_path = File.expand_path("../../build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")
     Dir.chdir(symbols_path) do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Crashlytics 심볼 업로드 중 오류가 발생해도 빌드가 중단되지 않고 오류 메시지만 기록되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->