### PR TITLE
feat: set bank api

### DIFF
--- a/lib/app/modules/user/data/data_source/remote/accounting_api.dart
+++ b/lib/app/modules/user/data/data_source/remote/accounting_api.dart
@@ -1,8 +1,8 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/core/data/dio/pot_dio.dart';
 import 'package:pot_g/app/modules/user/data/models/accounting_model.dart';
 import 'package:pot_g/app/modules/user/data/models/bank_model.dart';
-import 'package:pot_g/app/modules/user/data/models/self_user_model.dart';
 import 'package:pot_g/app/modules/user/data/models/set_accounting_model.dart';
 import 'package:retrofit/retrofit.dart';
 

--- a/lib/app/modules/user/data/data_source/remote/accounting_api.dart
+++ b/lib/app/modules/user/data/data_source/remote/accounting_api.dart
@@ -1,0 +1,22 @@
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/core/data/dio/pot_dio.dart';
+import 'package:pot_g/app/modules/user/data/models/accounting_model.dart';
+import 'package:pot_g/app/modules/user/data/models/bank_model.dart';
+import 'package:pot_g/app/modules/user/data/models/self_user_model.dart';
+import 'package:pot_g/app/modules/user/data/models/set_accounting_model.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'accounting_api.g.dart';
+
+@injectable
+@RestApi(baseUrl: '/api/v1/accounting/')
+abstract class AccountingApi {
+  @factoryMethod
+  factory AccountingApi(PotDio dio) = _AccountingApi;
+
+  @POST('me')
+  Future<AccountingModel> setAccounting(@Body() SetAccountingModel request);
+
+  @GET('bank')
+  Future<List<BankModel>> getBankList();
+}

--- a/lib/app/modules/user/data/models/bank_model.dart
+++ b/lib/app/modules/user/data/models/bank_model.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/user/domain/entities/bank_entity.dart';
+
+part 'bank_model.freezed.dart';
+part 'bank_model.g.dart';
+
+@freezed
+sealed class BankModel with _$BankModel implements BankEntity {
+  const BankModel._();
+  const factory BankModel({
+    required String id,
+    required String bankFullName,
+    required String logo,
+  }) = _BankModel;
+
+  factory BankModel.fromJson(Map<String, dynamic> json) =>
+      _$BankModelFromJson(json);
+
+  @override
+  String get name => bankFullName;
+  @override
+  String get logoUrl => logo;
+}

--- a/lib/app/modules/user/data/models/set_accounting_model.dart
+++ b/lib/app/modules/user/data/models/set_accounting_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'set_accounting_model.freezed.dart';
+part 'set_accounting_model.g.dart';
+
+@freezed
+sealed class SetAccountingModel with _$SetAccountingModel {
+  const factory SetAccountingModel({
+    required String bankPk,
+    required String account,
+  }) = _SetAccountingModel;
+
+  factory SetAccountingModel.fromJson(Map<String, dynamic> json) =>
+      _$SetAccountingModelFromJson(json);
+}

--- a/lib/app/modules/user/data/repositories/rest_accounting_repository.dart
+++ b/lib/app/modules/user/data/repositories/rest_accounting_repository.dart
@@ -1,0 +1,27 @@
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/user/data/data_source/remote/accounting_api.dart';
+import 'package:pot_g/app/modules/user/data/models/set_accounting_model.dart';
+import 'package:pot_g/app/modules/user/domain/entities/accounting_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/bank_entity.dart';
+import 'package:pot_g/app/modules/user/domain/repositories/accounting_repository.dart';
+
+@Injectable(as: AccountingRepository)
+class RestAccountingRepository implements AccountingRepository {
+  final AccountingApi _accountingApi;
+  RestAccountingRepository(this._accountingApi);
+
+  @override
+  Future<List<BankEntity>> getBankList() {
+    return _accountingApi.getBankList();
+  }
+
+  @override
+  Future<AccountingEntity> setAccounting(
+    BankEntity bank,
+    String accountNumber,
+  ) {
+    return _accountingApi.setAccounting(
+      SetAccountingModel(bankPk: bank.id, account: accountNumber),
+    );
+  }
+}

--- a/lib/app/modules/user/domain/entities/bank_entity.dart
+++ b/lib/app/modules/user/domain/entities/bank_entity.dart
@@ -1,0 +1,11 @@
+abstract class BankEntity {
+  const BankEntity({
+    required this.id,
+    required this.name,
+    required this.logoUrl,
+  });
+
+  final String id;
+  final String name;
+  final String logoUrl;
+}

--- a/lib/app/modules/user/domain/repositories/accounting_repository.dart
+++ b/lib/app/modules/user/domain/repositories/accounting_repository.dart
@@ -1,0 +1,7 @@
+import 'package:pot_g/app/modules/user/domain/entities/accounting_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/bank_entity.dart';
+
+abstract class AccountingRepository {
+  Future<AccountingEntity> setAccounting(BankEntity bank, String accountNumber);
+  Future<List<BankEntity>> getBankList();
+}

--- a/lib/app/modules/user/presentation/blocs/bank_list_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/bank_list_bloc.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/user/domain/entities/bank_entity.dart';
+import 'package:pot_g/app/modules/user/domain/repositories/accounting_repository.dart';
+
+part 'bank_list_bloc.freezed.dart';
+
+@injectable
+class BankListBloc extends Bloc<BankListEvent, BankListState> {
+  final AccountingRepository _accountingRepository;
+  BankListBloc(this._accountingRepository)
+    : super(const BankListState.initial()) {
+    on<_Load>(_onLoad);
+  }
+
+  Future<void> _onLoad(BankListEvent event, Emitter<BankListState> emit) async {
+    emit(const BankListState.loading());
+    try {
+      final banks = await _accountingRepository.getBankList();
+      emit(BankListState.loaded(banks));
+    } catch (e) {
+      emit(BankListState.error(e.toString()));
+    }
+  }
+}
+
+@freezed
+sealed class BankListEvent with _$BankListEvent {
+  const factory BankListEvent.load() = _Load;
+}
+
+@freezed
+sealed class BankListState with _$BankListState {
+  const BankListState._();
+
+  const factory BankListState.initial() = _Initial;
+  const factory BankListState.loading() = _Loading;
+  const factory BankListState.loaded(List<BankEntity> banks) = _Loaded;
+  const factory BankListState.error(String message) = _Error;
+
+  List<BankEntity> get banks => switch (this) {
+    _Loaded(:final banks) => banks,
+    _ => [],
+  };
+}


### PR DESCRIPTION
- **feat: add accounting list, set api**
- **feat: get bank list from api**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 은행 목록을 서버에서 동적으로 조회하고 선택할 수 있습니다(로딩/오류 상태 표시).
  - 선택한 은행과 계좌번호로 계정 연동(계좌 설정) 기능을 추가했습니다.
  - 계정 설정 페이지에서 정적 은행 목록을 제거하고, 동적 리스트와 이미지 표시를 지원합니다.
  - 은행 선택 상태가 다음 단계(계좌번호 입력)까지 자연스럽게 전달됩니다.
  - 표시 정보 정교화: 은행명·로고 노출 개선으로 가독성과 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->