### PR TITLE
feat: chat socket

### DIFF
--- a/lib/app/modules/auth/data/repositories/oauth_rest_auth_repository.dart
+++ b/lib/app/modules/auth/data/repositories/oauth_rest_auth_repository.dart
@@ -6,7 +6,7 @@ import 'package:pot_g/app/modules/auth/domain/repositories/auth_repository.dart'
 import 'package:pot_g/app/modules/auth/domain/repositories/oauth_repository.dart';
 import 'package:pot_g/app/modules/auth/domain/repositories/token_repository.dart';
 import 'package:pot_g/app/modules/device/domain/repositories/device_info_repository.dart';
-import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 import 'package:rxdart/streams.dart';
 
 @Injectable(as: AuthRepository)
@@ -27,7 +27,7 @@ class OauthRestAuthRepository implements AuthRepository {
   Stream<bool> get isSignedIn => user.map((user) => user != null);
 
   @override
-  Future<UserEntity> signIn() async {
+  Future<SelfUserEntity> signIn() async {
     final deviceId = await _deviceInfoRepository.getDeviceId();
     final idPToken = await _oAuthRepository.getToken();
     final token = await _userAuthApi.login(
@@ -53,7 +53,7 @@ class OauthRestAuthRepository implements AuthRepository {
   }
 
   @override
-  Stream<UserEntity?> get user => _tokenRepository.token
+  Stream<SelfUserEntity?> get user => _tokenRepository.token
       .asyncMap((token) async {
         if (token == null) return null;
         try {

--- a/lib/app/modules/auth/domain/repositories/auth_repository.dart
+++ b/lib/app/modules/auth/domain/repositories/auth_repository.dart
@@ -1,8 +1,8 @@
-import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 
 abstract class AuthRepository {
-  Future<UserEntity> signIn();
+  Future<SelfUserEntity> signIn();
   Stream<bool> get isSignedIn;
   Future<void> signOut();
-  Stream<UserEntity?> get user;
+  Stream<SelfUserEntity?> get user;
 }

--- a/lib/app/modules/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/app/modules/auth/presentation/bloc/auth_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
@@ -45,6 +46,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     emit(const AuthState.unauthenticated());
     await _repository.signOut();
   }
+
+  static SelfUserEntity? userOf(BuildContext context) =>
+      context.read<AuthBloc>().state.user;
 }
 
 @freezed

--- a/lib/app/modules/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/app/modules/auth/presentation/bloc/auth_bloc.dart
@@ -2,7 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/auth/domain/repositories/auth_repository.dart';
-import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 
 part 'auth_bloc.freezed.dart';
 
@@ -61,10 +61,10 @@ sealed class AuthState with _$AuthState {
   const factory AuthState.initial() = AuthInitial;
   const factory AuthState.loading() = AuthLoading;
   const factory AuthState.unauthenticated() = Unauthenticated;
-  const factory AuthState.authenticated(UserEntity user) = Authenticated;
+  const factory AuthState.authenticated(SelfUserEntity user) = Authenticated;
   const factory AuthState.error(String message) = AuthError;
 
-  UserEntity? get user => switch (this) {
+  SelfUserEntity? get user => switch (this) {
     Authenticated(:final user) => user,
     _ => null,
   };

--- a/lib/app/modules/chat/data/data_sources/remote/chat_pot_api.dart
+++ b/lib/app/modules/chat/data/data_sources/remote/chat_pot_api.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/data/models/pot_info_model.dart';
 import 'package:pot_g/app/modules/core/data/dio/pot_dio.dart';

--- a/lib/app/modules/chat/data/data_sources/remote/chat_pot_api.dart
+++ b/lib/app/modules/chat/data/data_sources/remote/chat_pot_api.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/data/models/pot_info_model.dart';
+import 'package:pot_g/app/modules/core/data/dio/pot_dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'chat_pot_api.g.dart';
+
+@injectable
+@RestApi(baseUrl: '/api/v1/pot/')
+abstract class ChatPotApi {
+  @factoryMethod
+  factory ChatPotApi(PotDio dio) = _ChatPotApi;
+
+  @GET('{id}/info')
+  Future<PotInfoModel> getPotInfo(@Path('id') String id);
+}

--- a/lib/app/modules/chat/data/enums/pot_status.dart
+++ b/lib/app/modules/chat/data/enums/pot_status.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum(fieldRename: FieldRename.screamingSnake)
+enum PotStatus {
+  /// 확정 전
+  beforeConfirmed,
+
+  /// 확정
+  confirmed,
+
+  /// 정산 전
+  waitAccounting,
+
+  /// 정산 완료
+  accountingDone,
+
+  /// 해산
+  archived,
+}

--- a/lib/app/modules/chat/data/models/pot_accounting_info_model.dart
+++ b/lib/app/modules/chat/data/models/pot_accounting_info_model.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pot_accounting_info_model.freezed.dart';
+part 'pot_accounting_info_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class PotAccountingInfoModel with _$PotAccountingInfoModel {
+  const factory PotAccountingInfoModel({
+    required bool requested,
+    required String? requestingUser,
+    required List<String> requestedUsers,
+  }) = _PotAccountingInfoModel;
+
+  factory PotAccountingInfoModel.fromJson(Map<String, dynamic> json) =>
+      _$PotAccountingInfoModelFromJson(json);
+}

--- a/lib/app/modules/chat/data/models/pot_info_model.dart
+++ b/lib/app/modules/chat/data/models/pot_info_model.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/chat/data/enums/pot_status.dart';
+import 'package:pot_g/app/modules/chat/data/models/pot_accounting_info_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/pot_users_info_model.dart';
+import 'package:pot_g/app/modules/core/data/models/route_model.dart';
+
+part 'pot_info_model.freezed.dart';
+part 'pot_info_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class PotInfoModel with _$PotInfoModel {
+  const factory PotInfoModel({
+    required String id,
+    required String name,
+    required RouteModel route,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    required DateTime? departureTime,
+    required PotStatus status,
+    required PotUsersInfoModel usersInfo,
+    required PotAccountingInfoModel accountingInfo,
+  }) = _PotInfoModel;
+
+  factory PotInfoModel.fromJson(Map<String, dynamic> json) =>
+      _$PotInfoModelFromJson(json);
+}

--- a/lib/app/modules/chat/data/models/pot_user_model.dart
+++ b/lib/app/modules/chat/data/models/pot_user_model.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pot_user_model.freezed.dart';
+part 'pot_user_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class PotUserModel with _$PotUserModel {
+  const factory PotUserModel({
+    required String id,
+    required String name,
+    required bool isHost,
+    required bool isInPot,
+  }) = _PotUserModel;
+
+  factory PotUserModel.fromJson(Map<String, dynamic> json) =>
+      _$PotUserModelFromJson(json);
+}

--- a/lib/app/modules/chat/data/models/pot_user_model.dart
+++ b/lib/app/modules/chat/data/models/pot_user_model.dart
@@ -1,10 +1,11 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
 
 part 'pot_user_model.freezed.dart';
 part 'pot_user_model.g.dart';
 
 @Freezed(toJson: false)
-sealed class PotUserModel with _$PotUserModel {
+sealed class PotUserModel with _$PotUserModel implements UserEntity {
   const factory PotUserModel({
     required String id,
     required String name,

--- a/lib/app/modules/chat/data/models/pot_users_info_model.dart
+++ b/lib/app/modules/chat/data/models/pot_users_info_model.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/chat/data/models/pot_user_model.dart';
+
+part 'pot_users_info_model.freezed.dart';
+part 'pot_users_info_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class PotUsersInfoModel with _$PotUsersInfoModel {
+  const factory PotUsersInfoModel({
+    required int current,
+    required int total,
+    required List<PotUserModel> users,
+  }) = _PotUsersInfoModel;
+
+  factory PotUsersInfoModel.fromJson(Map<String, dynamic> json) =>
+      _$PotUsersInfoModelFromJson(json);
+}

--- a/lib/app/modules/chat/data/repositories/mock_chat_repository.dart
+++ b/lib/app/modules/chat/data/repositories/mock_chat_repository.dart
@@ -2,29 +2,21 @@ import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/auth/domain/repositories/auth_repository.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/chat_repository.dart';
+import 'package:pot_g/app/modules/core/domain/entities/pot_entity.dart';
 import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
 
-@Injectable(as: ChatRepository)
+@Injectable(as: ChatRepository, env: [Environment.test])
 class MockChatRepository implements ChatRepository {
   final AuthRepository _authRepository;
 
   MockChatRepository(this._authRepository);
 
   @override
-  Future<List<ChatEntity>> getChats() async {
+  Future<List<ChatEntity>> getChats(PotEntity pot) async {
     final me =
-        await _authRepository.user.first ??
-        UserEntity(email: 'me@gistory.me', name: 'Me', uuid: 'me');
-    final hong = UserEntity(
-      email: 'hong@gistory.me',
-      name: '홍길동',
-      uuid: 'hong',
-    );
-    final shim = UserEntity(
-      email: 'shim@gistory.me',
-      name: '심청이',
-      uuid: 'shim',
-    );
+        await _authRepository.user.first ?? UserEntity(name: 'Me', id: 'me');
+    final hong = UserEntity(name: '홍길동', id: 'hong');
+    final shim = UserEntity(name: '심청이', id: 'shim');
 
     return [
       ChatEntity.make('첫 메시지', hong),
@@ -46,5 +38,17 @@ class MockChatRepository implements ChatRepository {
         shim,
       ),
     ];
+  }
+
+  @override
+  Stream<ChatEntity> getChatsStream(PotEntity pot) {
+    // TODO: implement getChatsStream
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> sendChat(String message, PotEntity pot) {
+    // TODO: implement sendChat
+    throw UnimplementedError();
   }
 }

--- a/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
@@ -1,0 +1,45 @@
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_pot_api.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/repositories/chat_repository.dart';
+import 'package:pot_g/app/modules/core/domain/entities/pot_entity.dart';
+import 'package:pot_g/app/modules/socket/data/data_sources/websocket.dart';
+import 'package:pot_g/app/modules/socket/data/models/events/pot_event_model.dart';
+import 'package:pot_g/app/modules/socket/data/models/events/send_chat_response_model.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/chat_v1_event.dart';
+import 'package:pot_g/app/modules/socket/data/models/requests/send_chat_model.dart';
+import 'package:uuid/uuid.dart';
+
+@Injectable(as: ChatRepository)
+class WebsocketChatRepository implements ChatRepository {
+  final PotGSocket _socket;
+  final ChatPotApi _api;
+
+  WebsocketChatRepository(this._socket, this._api);
+
+  @override
+  Future<List<ChatEntity>> getChats(PotEntity pot) async {
+    return [];
+  }
+
+  @override
+  Stream<ChatEntity> getChatsStream(PotEntity pot) async* {
+    final info = await _api.getPotInfo(pot.id);
+    final users = info.usersInfo.users;
+    yield* _socket.createStreamFor<PotEventModel<ChatV1Event>>().map((event) {
+      final e = event.body.data;
+      return ChatEntity(
+        id: Uuid().v4(),
+        message: e.content,
+        user: users.firstWhere((u) => u.id == e.from),
+        createdAt: DateTime.now(),
+      );
+    });
+  }
+
+  @override
+  Future<void> sendChat(String message, PotEntity pot) async {
+    await _socket.sendRequest(SendChatModel(message: message, potPk: pot.id));
+    await _socket.getNextMessage<SendChatResponseModel>();
+  }
+}

--- a/lib/app/modules/chat/domain/repositories/chat_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/chat_repository.dart
@@ -1,5 +1,8 @@
 import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
+import 'package:pot_g/app/modules/core/domain/entities/pot_entity.dart';
 
 abstract class ChatRepository {
-  Future<List<ChatEntity>> getChats();
+  Future<List<ChatEntity>> getChats(PotEntity pot);
+  Future<void> sendChat(String message, PotEntity pot);
+  Stream<ChatEntity> getChatsStream(PotEntity pot);
 }

--- a/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
@@ -3,31 +3,50 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/chat_repository.dart';
+import 'package:pot_g/app/modules/core/domain/entities/pot_entity.dart';
 
 part 'chat_bloc.freezed.dart';
 
 @injectable
 class ChatBloc extends Bloc<ChatEvent, ChatState> {
   final ChatRepository _chatRepository;
+  late final PotEntity _pot;
 
   ChatBloc(this._chatRepository) : super(const ChatInitial()) {
     on<ChatInit>(_onChatInit);
+    on<ChatSendChat>(_onChatSendChat);
   }
 
   Future<void> _onChatInit(ChatInit event, Emitter<ChatState> emit) async {
     emit(const ChatState.loading());
+    _pot = event.pot;
     try {
-      final chats = await _chatRepository.getChats();
+      final chats = await _chatRepository.getChats(event.pot);
       emit(ChatState.loaded(chats));
+      return emit.forEach(
+        _chatRepository.getChatsStream(event.pot),
+        onData: (chat) {
+          return ChatState.loaded([...state.chats, chat]);
+        },
+      );
     } catch (e) {
       emit(ChatState.error(state.chats, e.toString()));
     }
+  }
+
+  Future<void> _onChatSendChat(
+    ChatSendChat event,
+    Emitter<ChatState> emit,
+  ) async {
+    await _chatRepository.sendChat(event.message, _pot);
+    // TODO: optimistic UI
   }
 }
 
 @freezed
 sealed class ChatEvent with _$ChatEvent {
-  const factory ChatEvent.init() = ChatInit;
+  const factory ChatEvent.init(PotEntity pot) = ChatInit;
+  const factory ChatEvent.sendChat(String message) = ChatSendChat;
 }
 
 @freezed

--- a/lib/app/modules/chat/presentation/pages/chat_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_page.dart
@@ -13,7 +13,9 @@ class ChatPage extends StatelessWidget {
       child: PotButton(
         variant: PotButtonVariant.emphasized,
         onPressed: () {
-          context.router.push(ChatRoomRoute(id: '1'));
+          context.router.push(
+            ChatRoomRoute(id: '22b59c12-a22c-441b-8efe-de75bc7e8fbf'),
+          );
         },
         child: Text('To Chat Room'),
       ),

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -7,6 +7,7 @@ import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_bubble.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_icon_button.dart';
 import 'package:pot_g/app/modules/core/data/models/pot_model.dart';
 import 'package:pot_g/app/modules/core/data/models/route_model.dart';
 import 'package:pot_g/app/modules/core/data/models/stop_model.dart';
@@ -158,8 +159,18 @@ class _ChatInputState extends State<_ChatInput> {
             ),
           ),
           const SizedBox(width: 12),
-          Assets.icons.sendDiagonal.svg(
-            colorFilter: ColorFilter.mode(Palette.grey, BlendMode.srcIn),
+          SizedBox(
+            width: 24,
+            height: 24,
+            child: PotIconButton(
+              icon: Assets.icons.sendDiagonal.svg(
+                colorFilter: ColorFilter.mode(Palette.grey, BlendMode.srcIn),
+              ),
+              onPressed: () {
+                context.read<ChatBloc>().add(ChatSendChat(_controller.text));
+                _controller.clear();
+              },
+            ),
           ),
           const SizedBox(width: 12),
         ],

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -7,6 +7,9 @@ import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_bubble.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
+import 'package:pot_g/app/modules/core/data/models/pot_model.dart';
+import 'package:pot_g/app/modules/core/data/models/route_model.dart';
+import 'package:pot_g/app/modules/core/data/models/stop_model.dart';
 import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/app/values/text_styles.dart';
 import 'package:pot_g/gen/assets.gen.dart';
@@ -20,7 +23,24 @@ class ChatRoomPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => sl<ChatBloc>()..add(ChatInit()),
+      create:
+          (context) =>
+              sl<ChatBloc>()..add(
+                ChatInit(
+                  PotModel(
+                    id: id,
+                    current: 1,
+                    endsAt: DateTime.now(),
+                    startsAt: DateTime.now(),
+                    route: RouteModel(
+                      id: id,
+                      from: StopModel(id: id, name: ''),
+                      to: StopModel(id: id, name: ''),
+                    ),
+                    total: 4,
+                  ),
+                ),
+              ),
       child: Scaffold(
         appBar: PotAppBar(title: Text('지송 003')),
         endDrawer: Drawer(),
@@ -49,7 +69,7 @@ class _ChatList extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ChatBloc, ChatState>(
       builder: (context, state) {
-        final chats = state.chats.groupListsBy((chat) => chat.user.uuid).values;
+        final chats = state.chats.groupListsBy((chat) => chat.user.id).values;
         return Column(
           children:
               chats
@@ -82,7 +102,7 @@ class _ChatList extends StatelessWidget {
   Widget _buildChat(ChatEntity chat, bool isFirst) {
     return ChatBubble(
       message: chat.message,
-      user: chat.user.uuid == 'me' ? null : chat.user,
+      user: chat.user.id == 'me' ? null : chat.user,
       isFirst: isFirst,
     );
   }

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/di/locator.dart';
+import 'package:pot_g/app/modules/auth/presentation/bloc/auth_bloc.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_bubble.dart';
@@ -101,10 +102,14 @@ class _ChatList extends StatelessWidget {
   }
 
   Widget _buildChat(ChatEntity chat, bool isFirst) {
-    return ChatBubble(
-      message: chat.message,
-      user: chat.user.id == 'me' ? null : chat.user,
-      isFirst: isFirst,
+    return Builder(
+      builder:
+          (context) => ChatBubble(
+            message: chat.message,
+            user:
+                chat.user.id == AuthBloc.userOf(context)?.id ? null : chat.user,
+            isFirst: isFirst,
+          ),
     );
   }
 }

--- a/lib/app/modules/socket/data/models/converter/client_converter.dart
+++ b/lib/app/modules/socket/data/models/converter/client_converter.dart
@@ -1,5 +1,6 @@
 import 'package:pot_g/app/modules/socket/data/models/base/base_socket_request_model.dart';
 import 'package:pot_g/app/modules/socket/data/models/requests/authorization_model.dart';
+import 'package:pot_g/app/modules/socket/data/models/requests/send_chat_model.dart';
 import 'package:uuid/uuid.dart';
 
 Map<String, dynamic> convertClientMessage<T extends BaseSocketRequestEvent>(
@@ -13,6 +14,7 @@ Map<String, dynamic> convertClientMessage<T extends BaseSocketRequestEvent>(
   );
   final data = switch (request) {
     AuthorizationModel() => m.copyWith(type: 'authorization'),
+    SendChatModel() => m.copyWith(type: 'send_chat'),
     _ =>
       throw ArgumentError.value(
         request,

--- a/lib/app/modules/socket/data/models/converter/server_converter.dart
+++ b/lib/app/modules/socket/data/models/converter/server_converter.dart
@@ -26,7 +26,7 @@ BaseServerMessageModel<T> convertServerMessage<
     ),
   );
   final data = switch (type) {
-    'pot_event' => switch (jsonData['event_type']) {
+    'pot_event_receive' => switch (jsonData['event_type']) {
       'chat_v1' => changePotEvent(ChatV1Event.fromJson),
       'user_in_v1' => changePotEvent(UserInV1Event.fromJson),
       _ =>

--- a/lib/app/modules/socket/data/models/converter/server_converter.dart
+++ b/lib/app/modules/socket/data/models/converter/server_converter.dart
@@ -2,6 +2,7 @@ import 'package:pot_g/app/modules/socket/data/models/base/base_server_message_mo
 import 'package:pot_g/app/modules/socket/data/models/events/authorization_response_model.dart';
 import 'package:pot_g/app/modules/socket/data/models/events/pot_event_model.dart';
 import 'package:pot_g/app/modules/socket/data/models/events/request_authorization_event_model.dart';
+import 'package:pot_g/app/modules/socket/data/models/events/send_chat_response_model.dart';
 import 'package:pot_g/app/modules/socket/data/models/pot_events/chat_v1_event.dart';
 import 'package:pot_g/app/modules/socket/data/models/pot_events/user_in_v1_event.dart';
 
@@ -37,6 +38,7 @@ BaseServerMessageModel<T> convertServerMessage<
     },
     'request_authorization' => change(RequestAuthorizationEventModel.fromJson),
     'authorization_res' => change(AuthorizationResponseModel.fromJson),
+    'send_chat_res' => change(SendChatResponseModel.fromJson),
     _ => throw ArgumentError.value(jsonData, 'jsonData', 'Unknown type: $type'),
   };
   return data as BaseServerMessageModel<T>;

--- a/lib/app/modules/socket/data/models/converter/server_converter.dart
+++ b/lib/app/modules/socket/data/models/converter/server_converter.dart
@@ -26,7 +26,7 @@ BaseServerMessageModel<T> convertServerMessage<
     ),
   );
   final data = switch (type) {
-    'pot_event_receive' => switch (jsonData['event_type']) {
+    'pot_event_receive' => switch (jsonData['body']['event_type']) {
       'chat_v1' => changePotEvent(ChatV1Event.fromJson),
       'user_in_v1' => changePotEvent(UserInV1Event.fromJson),
       _ =>

--- a/lib/app/modules/socket/data/models/events/pot_event_model.dart
+++ b/lib/app/modules/socket/data/models/events/pot_event_model.dart
@@ -11,7 +11,7 @@ sealed class PotEventModel<T extends PotEvent>
     with _$PotEventModel<T>
     implements BaseServerMessageEvent {
   const factory PotEventModel({
-    required String potFk,
+    required String potPk,
     @EpochDateTimeConverter() required DateTime timestamp,
     required String eventType,
     required T data,

--- a/lib/app/modules/socket/data/models/events/send_chat_response_model.dart
+++ b/lib/app/modules/socket/data/models/events/send_chat_response_model.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/socket/data/models/base/base_server_message_model.dart';
+
+part 'send_chat_response_model.freezed.dart';
+part 'send_chat_response_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class SendChatResponseModel
+    with _$SendChatResponseModel
+    implements BaseServerMessageEvent {
+  const factory SendChatResponseModel({
+    required int responseCode,
+    required String result,
+  }) = _SendChatResponseModel;
+
+  factory SendChatResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$SendChatResponseModelFromJson(json);
+}

--- a/lib/app/modules/socket/data/models/requests/send_chat_model.dart
+++ b/lib/app/modules/socket/data/models/requests/send_chat_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pot_g/app/modules/socket/data/models/base/base_socket_request_model.dart';
+
+part 'send_chat_model.freezed.dart';
+part 'send_chat_model.g.dart';
+
+@Freezed(fromJson: false, toJson: true)
+sealed class SendChatModel
+    with _$SendChatModel
+    implements BaseSocketRequestEvent {
+  const factory SendChatModel({
+    required String message,
+    required String potPk,
+  }) = _SendChatModel;
+}

--- a/lib/app/modules/socket/data/repositories/websocket_socket_authorization_repository.dart
+++ b/lib/app/modules/socket/data/repositories/websocket_socket_authorization_repository.dart
@@ -8,7 +8,7 @@ import 'package:pot_g/app/modules/socket/data/models/events/request_authorizatio
 import 'package:pot_g/app/modules/socket/data/models/requests/authorization_model.dart';
 import 'package:pot_g/app/modules/socket/domain/socket_authorization_repository.dart';
 
-@LazySingleton(as: SocketAuthorizationRepository)
+@Singleton(as: SocketAuthorizationRepository)
 class WebsocketSocketAuthorizationRepository
     implements SocketAuthorizationRepository {
   final PotGSocket _socket;

--- a/lib/app/modules/user/data/models/self_user_model.dart
+++ b/lib/app/modules/user/data/models/self_user_model.dart
@@ -20,5 +20,5 @@ sealed class SelfUserModel with _$SelfUserModel implements UserEntity {
       _$SelfUserModelFromJson(json);
 
   @override
-  String get uuid => 'me';
+  String get id => 'me';
 }

--- a/lib/app/modules/user/data/models/self_user_model.dart
+++ b/lib/app/modules/user/data/models/self_user_model.dart
@@ -1,13 +1,13 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pot_g/app/modules/user/data/models/accounting_model.dart';
 import 'package:pot_g/app/modules/user/data/models/push_setting_model.dart';
-import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 
 part 'self_user_model.freezed.dart';
 part 'self_user_model.g.dart';
 
 @freezed
-sealed class SelfUserModel with _$SelfUserModel implements UserEntity {
+sealed class SelfUserModel with _$SelfUserModel implements SelfUserEntity {
   const SelfUserModel._();
   const factory SelfUserModel({
     required String name,
@@ -20,5 +20,6 @@ sealed class SelfUserModel with _$SelfUserModel implements UserEntity {
       _$SelfUserModelFromJson(json);
 
   @override
+  // TODO: change this
   String get id => 'me';
 }

--- a/lib/app/modules/user/data/models/self_user_model.dart
+++ b/lib/app/modules/user/data/models/self_user_model.dart
@@ -10,6 +10,7 @@ part 'self_user_model.g.dart';
 sealed class SelfUserModel with _$SelfUserModel implements SelfUserEntity {
   const SelfUserModel._();
   const factory SelfUserModel({
+    required String id,
     required String name,
     required String email,
     required AccountingModel accounting,
@@ -18,8 +19,4 @@ sealed class SelfUserModel with _$SelfUserModel implements SelfUserEntity {
 
   factory SelfUserModel.fromJson(Map<String, dynamic> json) =>
       _$SelfUserModelFromJson(json);
-
-  @override
-  // TODO: change this
-  String get id => 'me';
 }

--- a/lib/app/modules/user/domain/entities/self_user_entity.dart
+++ b/lib/app/modules/user/domain/entities/self_user_entity.dart
@@ -1,0 +1,11 @@
+import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+
+class SelfUserEntity extends UserEntity {
+  final String email;
+
+  const SelfUserEntity({
+    required this.email,
+    required super.id,
+    required super.name,
+  });
+}

--- a/lib/app/modules/user/domain/entities/user_entity.dart
+++ b/lib/app/modules/user/domain/entities/user_entity.dart
@@ -1,6 +1,4 @@
 class UserEntity {
-  /// 자신인 경우에는 `me` 를 사용합니다.
-  /// 추후 서버 설계에 따라 달라질 수 있습니다
   final String id;
   final String name;
 

--- a/lib/app/modules/user/domain/entities/user_entity.dart
+++ b/lib/app/modules/user/domain/entities/user_entity.dart
@@ -1,13 +1,8 @@
 class UserEntity {
   /// 자신인 경우에는 `me` 를 사용합니다.
   /// 추후 서버 설계에 따라 달라질 수 있습니다
-  final String uuid;
-  final String email;
+  final String id;
   final String name;
 
-  const UserEntity({
-    required this.uuid,
-    required this.email,
-    required this.name,
-  });
+  const UserEntity({required this.id, required this.name});
 }

--- a/lib/app/modules/user/presentation/pages/profile_page.dart
+++ b/lib/app/modules/user/presentation/pages/profile_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/modules/auth/presentation/bloc/auth_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_pressable.dart';
-import 'package:pot_g/app/modules/user/domain/entities/user_entity.dart';
+import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/app/values/text_styles.dart';
@@ -30,7 +30,7 @@ class ProfilePage extends StatelessWidget {
 class _Inner extends StatelessWidget {
   const _Inner({required this.user});
 
-  final UserEntity user;
+  final SelfUserEntity user;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/f47a16b5-0c90-46fd-86b1-b924c58389e2

- **chore: test chat room id**
- **feat: pot info api**
- **feat: send chat, send chat res**
- **feat: pot user model implements UserEntity**
- **feat: add self user entity**
- **feat: add chat repository**
- **fix: create only one raw message stream controller**
- **feat: send chat**
- **fix: `pot_event` -> `pot_event_receive`**
- **fix: pot event type switch**
- **fix: `potFk` -> `potPk`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 실시간 채팅 스트림 수신 및 메시지 전송 지원 (웹소켓 기반)
  - Pot 정보 조회용 원격 API 및 Pot 관련 데이터 모델(PotInfo, 사용자/정산 정보, 상태 등) 추가

- **개선/변경**
  - 사용자 타입을 SelfUser로 통일해 내 프로필 정보 정확성 향상 및 프로필 화면 업데이트
  - 채팅 사용 시 Pot 선택이 필수화되고 채팅방 진입 파라미터가 실제 식별자 기반으로 변경
  - 인증 컨텍스트에서 현재 사용자 조회용 헬퍼 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->