### PR TITLE
fix: wrong pot filtering in chat

### DIFF
--- a/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
@@ -28,9 +28,9 @@ class WebsocketChatRepository implements ChatRepository {
     final users = info.usersInfo.users;
     yield* _socket
         .createStreamFor<PotEventModel<ChatV1Event>>()
-        .where((e) => e.body.data.from == pot.id)
-        .map((event) {
-          final e = event.body.data;
+        .where((e) => e.body.potPk == pot.id)
+        .map((e) => e.body.data)
+        .map((e) {
           return ChatEntity(
             id: Uuid().v4(),
             message: e.content,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 실시간 채팅에서 잘못 분류되던 메시지가 올바른 대화에 표시되도록 수정했습니다.
  - 특정 대화에서 메시지가 누락되거나 다른 대화에 나타나던 이슈를 해소하여 타임라인 정합성을 개선했습니다.
- 리팩터링
  - 데이터 매핑 흐름을 단순화하여 스트림 처리 경로를 정리했습니다.
  - 사용자 관점에서 초기 수신 지연과 일시적 깜빡임이 줄어들고, 실시간 업데이트 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->