### PR TITLE
feat: enable send button when chat input filled

### DIFF
--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -244,6 +244,15 @@ class _ChatInput extends StatefulWidget {
 
 class _ChatInputState extends State<_ChatInput> {
   final _controller = TextEditingController();
+  bool _filled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      setState(() => _filled = _controller.text.isNotEmpty);
+    });
+  }
 
   @override
   void dispose() {
@@ -284,7 +293,10 @@ class _ChatInputState extends State<_ChatInput> {
           const SizedBox(width: 6),
           PotIconButton(
             icon: Assets.icons.sendDiagonal.svg(
-              colorFilter: ColorFilter.mode(Palette.grey, BlendMode.srcIn),
+              colorFilter: ColorFilter.mode(
+                _filled ? Palette.primary : Palette.grey,
+                BlendMode.srcIn,
+              ),
             ),
             onPressed: () {
               context.read<ChatBloc>().add(ChatSendChat(_controller.text));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 채팅 화면에서 입력란이 비어있지 않을 때 전송 버튼이 기본 색상으로, 비어 있을 때는 회색으로 표시됩니다.
  * 입력 내용 변화가 즉시 반영되어 전송 가능 여부를 직관적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->