### PR TITLE
feat: hide report button from chat room drawer

### DIFF
--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -92,18 +92,6 @@ class _Layout extends StatelessWidget {
                         ),
                       ),
                     ),
-                    const SizedBox(width: 16),
-                    PotPressable(
-                      onTap: () {},
-                      child: Text(
-                        context.t.chat_room.drawer.actions.report,
-                        style: TextStyles.caption.copyWith(
-                          color: Palette.grey,
-                          decoration: TextDecoration.underline,
-                          decorationColor: Palette.grey,
-                        ),
-                      ),
-                    ),
                   ],
                 ),
               ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  - 채팅방 화면의 엔드 드로어에서 "신고" 액션을 제거했습니다. 이제 드로어에는 "나가기"만 표시되며, 더 단순한 액션 목록을 제공합니다.
* Style
  - 액션 버튼 사이의 가로 간격을 축소하여 공간 활용을 개선했습니다. 시각적 잡음을 줄이고 보다 깔끔한 레이아웃을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->