### PR TITLE
fix: prevent set departure time of already set

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -183,6 +183,9 @@
       },
       "host_only": {
         "description": "This feature is only available for hosts."
+      },
+      "already_set": {
+        "description": "The departure time has already been set."
       }
     },
     "accounting": {

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -177,6 +177,12 @@ class _SetDepartureTimeButton extends StatelessWidget {
           );
           return;
         }
+        if (pot.departureTime != null) {
+          context.showToast(
+            context.t.chat_room.set_departure_time.already_set.description,
+          );
+          return;
+        }
         DateTime date = DateTime.now();
         final result = await showGeneralOkCancelAdaptiveDialog(
           context: context,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 출발 시간이 이미 설정된 경우를 안내하는 새로운 문구가 추가되어 더 명확한 피드백을 제공합니다(영어 현지화 포함).

- 버그 수정
  - 출발 시간이 이미 설정된 대화방에서 ‘출발 시간 설정’ 버튼을 눌러도 선택기가 열리지 않으며, 토스트로 상태를 안내해 중복 설정을 방지합니다. 이를 통해 불필요한 흐름 진입을 차단하고 UX 일관성과 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->