### PR TITLE
feat: sidebar after departure confirmed

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -170,14 +170,23 @@
       "members": {
         "my": "my",
         "passenger": "passengers",
+        "departure_confirmed": "Already confirmed pot",
         "kick": {
           "action": "Kick",
           "confirm": {
             "title": "Kick Passenger?",
             "description(rich)": "Are you sure you want to kick $user?\nIf the kick is unreasonable, you may be reported."
-          }
+          },
+          "departure_confirmed": "After the departure time is confirmed, you cannot kick."
         },
-        "invite": "Invite",
+        "invite": {
+          "action": "Invite",
+          "success": {
+            "title": "Invite Link Copied",
+            "description": "The invite link has been copied.\nPlease send the link to your friend."
+          },
+          "departure_confirmed": "After the departure time is confirmed, you cannot invite."
+        },
         "host": "Host"
       },
       "actions": {
@@ -186,7 +195,8 @@
           "confirm": {
             "title": "Leave the pot?",
             "description": "You can leave freely before the departure time is confirmed. Do you want to leave?"
-          }
+          },
+          "departure_confirmed": "After the departure time is confirmed, you cannot leave."
         },
         "report": "Report"
       }

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -167,14 +167,23 @@
       "members": {
         "my": "my",
         "passenger": "동승자",
+        "departure_confirmed": "이미 확정된 팟입니다",
         "kick": {
           "action": "강퇴",
           "confirm": {
             "title": "동승자를 강퇴할까요?",
             "description(rich)": "$user를 강퇴할까요?\n불합리한 강퇴일 경우\n신고를 당할 수 있습니다"
-          }
+          },
+          "departure_confirmed": "출발 시간을 확정한 이후에는 강퇴가 불가능합니다"
         },
-        "invite": "초대하기",
+        "invite": {
+          "action": "초대하기",
+          "success": {
+            "title": "초대 링크 복사",
+            "description": "초대 링크가 복사 되었습니다\n친구에게 링크를 전송하세요"
+          },
+          "departure_confirmed": "출발 시간을 확정한 이후에는 초대가 불가능합니다"
+        },
         "host": "방장"
       },
       "actions": {
@@ -183,7 +192,8 @@
           "confirm": {
             "title": "퇴장하시겠습니까?",
             "description": "출발 시간 확정 이전에는\n자유로운 퇴장이 가능합니다\n퇴장하시겠습니까?"
-          }
+          },
+          "departure_confirmed": "출발 시간을 확정한 이후에는 퇴장이 불가능합니다"
         },
         "report": "신고하기"
       }

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -54,6 +54,14 @@ class ChatRoomDrawer extends StatelessWidget {
   }
 
   Future<void> _leave(BuildContext context) async {
+    if (pot.departureTime != null) {
+      showOkAlertDialog(
+        context: context,
+        title: context.t.chat_room.drawer.members.departure_confirmed,
+        message: context.t.chat_room.drawer.actions.leave.departure_confirmed,
+      );
+      return;
+    }
     final result = await showOkCancelAlertDialog(
       context: context,
       title: context.t.chat_room.drawer.actions.leave.confirm.title,

--- a/lib/app/modules/chat/presentation/widgets/pot_info.dart
+++ b/lib/app/modules/chat/presentation/widgets/pot_info.dart
@@ -29,7 +29,9 @@ class PotInfo extends StatelessWidget {
         _Field(
           label: context.t.chat_room.drawer.pot_info.departure_time,
           value:
-              '${DateFormat.Hm().format(pot.startsAt)}~${DateFormat.Hm().format(pot.endsAt)}',
+              pot.departureTime != null
+                  ? DateFormat.Hm().format(pot.departureTime!)
+                  : '${DateFormat.Hm().format(pot.startsAt)}~${DateFormat.Hm().format(pot.endsAt)}',
         ),
       ],
     );

--- a/lib/app/modules/chat/presentation/widgets/pot_users.dart
+++ b/lib/app/modules/chat/presentation/widgets/pot_users.dart
@@ -53,6 +53,14 @@ class PotUsers extends StatelessWidget {
   }
 
   Future<void> _kickUser(BuildContext context, PotUserEntity user) async {
+    if (pot.departureTime != null) {
+      showOkAlertDialog(
+        context: context,
+        title: context.t.chat_room.drawer.members.departure_confirmed,
+        message: context.t.chat_room.drawer.members.kick.departure_confirmed,
+      );
+      return;
+    }
     final result = await showGeneralOkCancelAdaptiveDialog(
       title: context.t.chat_room.drawer.members.kick.confirm.title,
       child: Text.rich(


### PR DESCRIPTION
- **chore: add translations**
- **feat: block leave message**
- **feat: block kick message**
- **feat: departure time**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 출발 시간이 확정된 팟에서는 초대·강퇴·퇴장 등 행동을 제한하고 경고 메시지를 표시합니다.
  - 채팅방 드로어와 멤버 목록에서 제한 조건을 사전 안내하여 불필요한 확인 모달을 방지합니다.
  - Pot 정보 화면에서 departureTime이 있으면 단일 출발 시각을, 없으면 기존 시작~종료 범위를 표시합니다.
  - 한/영 다국어 문자열을 보강하고 초대 성공 메시지 및 제약 안내 문구를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->