### PR TITLE
refactor: separate pot info bloc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: env.run == 'true'
         with:
-          flutter-version: "3.35.6"
+          flutter-version: "3.35.5"
           channel: "stable"
           cache: true
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: env.run == 'true'
         with:
-          flutter-version: "3.35.2"
+          flutter-version: "3.35.6"
           channel: "stable"
           cache: true
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           path: |
             .dart_tool
             !.dart_tool/**/*.snapshot
-          key: ${{ runner.os }}-dart-tool-${{ hashFiles('pubspec.lock') }}
+          key: ${{ runner.os }}-dart-tool-3.35.5-${{ hashFiles('pubspec.lock') }}
       - name: install flutterfire
         if: env.run == 'true'
         run: flutter pub global activate flutterfire_cli

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -71,7 +71,7 @@ jobs:
           path: |
             .dart_tool
             !.dart_tool/**/*.snapshot
-          key: ${{ runner.os }}-dart-tool-${{ hashFiles('pubspec.lock') }}
+          key: ${{ runner.os }}-dart-tool-3.35.5-${{ hashFiles('pubspec.lock') }}
       - name: install flutterfire
         run: flutter pub global activate flutterfire_cli
       - uses: actions/cache@v4

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.35.2"
+          flutter-version: "3.35.6"
           channel: "stable"
           cache: true
       - uses: actions/cache@v4

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.35.6"
+          flutter-version: "3.35.5"
           channel: "stable"
           cache: true
       - uses: actions/cache@v4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,12 +6,21 @@ PODS:
   - AmplitudeSwift (1.11.9):
     - AnalyticsConnector (~> 1.3.0)
   - AnalyticsConnector (1.3.1)
+  - app_links (6.4.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - Firebase/CoreOnly (11.15.0):
     - FirebaseCore (~> 11.15.0)
-  - firebase_core (3.15.1):
+  - Firebase/Messaging (11.15.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 11.15.0)
+  - firebase_core (3.15.2):
     - Firebase/CoreOnly (= 11.15.0)
+    - Flutter
+  - firebase_messaging (15.2.10):
+    - Firebase/Messaging (= 11.15.0)
+    - firebase_core
     - Flutter
   - FirebaseCore (11.15.0):
     - FirebaseCoreInternal (~> 11.15.0)
@@ -19,34 +28,78 @@ PODS:
     - GoogleUtilities/Logger (~> 8.1)
   - FirebaseCoreInternal (11.15.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FirebaseInstallations (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Reachability (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - flutter_native_splash (2.4.3):
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
   - flutter_web_auth_2 (3.0.0):
     - Flutter
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
   - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
   - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
   - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
+  - PromisesObjC (2.4.0)
   - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - amplitude_flutter (from `.symlinks/plugins/amplitude_flutter/darwin`)
+  - app_links (from `.symlinks/plugins/app_links/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
@@ -61,17 +114,28 @@ SPEC REPOS:
     - Firebase
     - FirebaseCore
     - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - GoogleDataTransport
     - GoogleUtilities
+    - nanopb
+    - PromisesObjC
 
 EXTERNAL SOURCES:
   amplitude_flutter:
     :path: ".symlinks/plugins/amplitude_flutter/darwin"
+  app_links:
+    :path: ".symlinks/plugins/app_links/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_messaging:
+    :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
@@ -89,18 +153,26 @@ SPEC CHECKSUMS:
   amplitude_flutter: 6d1f1befdf0c5601a44012331adb1ca207bcd02b
   AmplitudeSwift: 13a2ae0756d3c79f15e6e08807575d1ef49437a3
   AnalyticsConnector: 3def11199b4ddcad7202c778bde982ec5da0ebb3
+  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
-  firebase_core: ece862f94b2bc72ee0edbeec7ab5c7cb09fe1ab5
+  firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
+  firebase_messaging: f4a41dd102ac18b840eba3f39d67e77922d3f707
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
+  FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
+  FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce

--- a/lib/app/modules/chat/data/models/accounting_confirm_response_model.dart
+++ b/lib/app/modules/chat/data/models/accounting_confirm_response_model.dart
@@ -6,9 +6,20 @@ part 'accounting_confirm_response_model.g.dart';
 @Freezed(toJson: false)
 sealed class AccountingConfirmResponseModel
     with _$AccountingConfirmResponseModel {
-  const factory AccountingConfirmResponseModel({required String result}) =
-      _AccountingConfirmResponseModel;
+  const factory AccountingConfirmResponseModel({
+    required AccountingConfirmResult result,
+  }) = _AccountingConfirmResponseModel;
 
   factory AccountingConfirmResponseModel.fromJson(Map<String, dynamic> json) =>
       _$AccountingConfirmResponseModelFromJson(json);
+}
+
+@JsonEnum(fieldRename: FieldRename.pascal)
+enum AccountingConfirmResult {
+  @JsonValue('OK')
+  ok,
+  notYetRequested,
+  notAccountingRequester,
+  potNotExist,
+  potAlreadyClosed,
 }

--- a/lib/app/modules/chat/data/models/pot_accounting_info_model.dart
+++ b/lib/app/modules/chat/data/models/pot_accounting_info_model.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_accounting_info_entity.dart';
 
 part 'pot_accounting_info_model.freezed.dart';
@@ -9,15 +10,28 @@ part 'pot_accounting_info_model.g.dart';
 sealed class PotAccountingInfoModel
     with _$PotAccountingInfoModel
     implements PotAccountingInfoEntity {
+  const PotAccountingInfoModel._();
+
   const factory PotAccountingInfoModel({
     required String? requestingUser,
     required int? totalCost,
     required int? costPerUser,
     required String? bankName,
     required String? bankAccount,
-    required List<AccountingResultModel> accountingResults,
+    @JsonKey(name: 'accounting_results')
+    required List<AccountingResultModel> accounting,
   }) = _PotAccountingInfoModel;
 
   factory PotAccountingInfoModel.fromJson(Map<String, dynamic> json) =>
       _$PotAccountingInfoModelFromJson(json);
+
+  @override
+  List<AccountingResultEntity> get accountingResults => accounting
+      .map(
+        (e) => AccountingResultEntity(
+          userPk: e.userPk,
+          accountingDone: e.accountingDone,
+        ),
+      )
+      .toList();
 }

--- a/lib/app/modules/chat/data/repositories/websocket_pot_accounting_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_accounting_repository.dart
@@ -1,0 +1,92 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_accounting_api.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_confirm_request_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_confirm_response_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_request_request_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_request_response_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/accounting_confirm_exception.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/accounting_request_exception.dart';
+import 'package:pot_g/app/modules/chat/domain/repositories/pot_accounting_repository.dart';
+
+@Injectable(as: PotAccountingRepository)
+class WebsocketPotAccountingRepository implements PotAccountingRepository {
+  final ChatAccountingApi _accountingApi;
+
+  WebsocketPotAccountingRepository(this._accountingApi);
+
+  @override
+  Future<void> accounting(
+    PotInfoEntity pot,
+    int amount,
+    List<PotUserEntity> targets,
+  ) async {
+    try {
+      final result = await _accountingApi.requestAccounting(
+        pot.id,
+        AccountingRequestRequestModel(
+          totalCost: amount,
+          costPerUser: amount ~/ (targets.length + 1),
+          accountInfo: AccountInfo(useExistInfo: true),
+          requestedUser: targets.map((e) => e.id).toList(),
+        ),
+      );
+      switch (result.result) {
+        case AccountingResult.ok:
+          return;
+        case AccountingResult.alreadyRequested:
+          throw AccountingRequestException.alreadyRequested();
+        case AccountingResult.accountInfoNotSet:
+          throw AccountingRequestException.accountInfoNotSet();
+        case AccountingResult.costCannotBeNegative:
+          throw AccountingRequestException.costCannotBeNegative();
+        case AccountingResult.costPerUserMismatch:
+          throw AccountingRequestException.costPerUserMismatch();
+        case AccountingResult.beforeDeparture:
+          throw AccountingRequestException.beforeDeparture();
+        case AccountingResult.notAParticipant:
+          throw AccountingRequestException.notAParticipant();
+        case AccountingResult.potNotExist:
+          throw AccountingRequestException.potNotExist();
+        case AccountingResult.potAlreadyClosed:
+          throw AccountingRequestException.potAlreadyClosed();
+      }
+    } on DioException catch (e) {
+      throw AccountingRequestException.networkError(
+        e.message ?? e.error.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<void> confirmAccounting(
+    PotInfoEntity pot,
+    List<AccountingResultModel> accountingResults,
+  ) async {
+    try {
+      final result = await _accountingApi.confirmAccounting(
+        pot.id,
+        AccountingConfirmRequestModel(accountingResults: accountingResults),
+      );
+      switch (result.result) {
+        case AccountingConfirmResult.ok:
+          return;
+        case AccountingConfirmResult.notYetRequested:
+          throw AccountingConfirmException.notYetRequested();
+        case AccountingConfirmResult.notAccountingRequester:
+          throw AccountingConfirmException.notAccountingRequester();
+        case AccountingConfirmResult.potNotExist:
+          throw AccountingConfirmException.potNotExist();
+        case AccountingConfirmResult.potAlreadyClosed:
+          throw AccountingConfirmException.potAlreadyClosed();
+      }
+    } on DioException catch (e) {
+      throw AccountingConfirmException.networkError(
+        e.message ?? e.error.toString(),
+      );
+    }
+  }
+}

--- a/lib/app/modules/chat/data/repositories/websocket_pot_accounting_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_accounting_repository.dart
@@ -6,6 +6,7 @@ import 'package:pot_g/app/modules/chat/data/models/accounting_confirm_response_m
 import 'package:pot_g/app/modules/chat/data/models/accounting_request_request_model.dart';
 import 'package:pot_g/app/modules/chat/data/models/accounting_request_response_model.dart';
 import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/exceptions/accounting_confirm_exception.dart';
@@ -64,12 +65,14 @@ class WebsocketPotAccountingRepository implements PotAccountingRepository {
   @override
   Future<void> confirmAccounting(
     PotInfoEntity pot,
-    List<AccountingResultModel> accountingResults,
+    List<AccountingResultEntity> accountingResults,
   ) async {
     try {
       final result = await _accountingApi.confirmAccounting(
         pot.id,
-        AccountingConfirmRequestModel(accountingResults: accountingResults),
+        AccountingConfirmRequestModel(
+          accountingResults: accountingResults.map(_toModel).toList(),
+        ),
       );
       switch (result.result) {
         case AccountingConfirmResult.ok:
@@ -88,5 +91,12 @@ class WebsocketPotAccountingRepository implements PotAccountingRepository {
         e.message ?? e.error.toString(),
       );
     }
+  }
+
+  AccountingResultModel _toModel(AccountingResultEntity entity) {
+    return AccountingResultModel(
+      userPk: entity.userPk,
+      accountingDone: entity.accountingDone,
+    );
   }
 }

--- a/lib/app/modules/chat/data/repositories/websocket_pot_action_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_action_repository.dart
@@ -1,0 +1,98 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_pot_api.dart';
+import 'package:pot_g/app/modules/chat/data/models/confirm_departure_time_request_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/confirm_departure_time_response_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/kick_user_response_model.dart';
+import 'package:pot_g/app/modules/chat/data/models/leave_pot_response_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/departure_time_exception.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/kick_user_exception.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/leave_pot_exception.dart';
+import 'package:pot_g/app/modules/chat/domain/repositories/pot_action_repository.dart';
+
+@Injectable(as: PotActionRepository)
+class WebsocketPotActionRepository implements PotActionRepository {
+  final ChatPotApi _api;
+
+  WebsocketPotActionRepository(this._api);
+
+  @override
+  Future<void> setDepartureTime(PotInfoEntity pot, DateTime date) async {
+    try {
+      final result = await _api.confirmDepartureTime(
+        pot.id,
+        ConfirmDepartureTimeRequestModel(departureTime: date),
+      );
+      switch (result.result) {
+        case PotDepartureTimeResult.ok:
+          return;
+        case PotDepartureTimeResult.notAHost:
+          throw DepartureTimeException.notAHost();
+        case PotDepartureTimeResult.afterDeparture:
+          throw DepartureTimeException.afterDeparture();
+        case PotDepartureTimeResult.beforeNow:
+          throw DepartureTimeException.beforeNow();
+        case PotDepartureTimeResult.potNotExist:
+          throw DepartureTimeException.potNotExist();
+        case PotDepartureTimeResult.potAlreadyClosed:
+          throw DepartureTimeException.potAlreadyClosed();
+      }
+    } on DioException catch (e) {
+      throw DepartureTimeException.networkError(
+        e.message ?? e.error.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<void> kickUser(PotInfoEntity pot, PotUserEntity user) async {
+    try {
+      final result = await _api.kickUser(pot.id, user.id);
+      switch (result.result) {
+        case KickUserResult.ok:
+          return;
+        case KickUserResult.notAHost:
+          throw KickUserException.notAHost();
+        case KickUserResult.notAParticipant:
+          throw KickUserException.notAParticipant();
+        case KickUserResult.userNotInPot:
+          throw KickUserException.userNotInPot();
+        case KickUserResult.afterDepartureConfirmed:
+          throw KickUserException.afterDepartureConfirmed();
+        case KickUserResult.notYetPaymentConfirmed:
+          throw KickUserException.notYetPaymentConfirmed();
+        case KickUserResult.potNotExist:
+          throw KickUserException.potNotExist();
+        case KickUserResult.potAlreadyClosed:
+          throw KickUserException.potAlreadyClosed();
+      }
+    } on DioException catch (e) {
+      throw KickUserException.networkError(e.message ?? e.error.toString());
+    }
+  }
+
+  @override
+  Future<void> leavePot(PotInfoEntity pot) async {
+    try {
+      final result = await _api.leavePot(pot.id);
+      switch (result.result) {
+        case LeavePotResult.ok:
+          return;
+        case LeavePotResult.afterDepartureConfirmed:
+          throw LeavePotException.afterDepartureConfirmed();
+        case LeavePotResult.notYetPaymentConfirmed:
+          throw LeavePotException.notYetPaymentConfirmed();
+        case LeavePotResult.notYetPaymentCompleted:
+          throw LeavePotException.notYetPaymentCompleted();
+        case LeavePotResult.potNotExist:
+          throw LeavePotException.potNotExist();
+        case LeavePotResult.potAlreadyClosed:
+          throw LeavePotException.potAlreadyClosed();
+      }
+    } on DioException catch (e) {
+      throw LeavePotException.networkError(e.message ?? e.error.toString());
+    }
+  }
+}

--- a/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
@@ -1,22 +1,6 @@
-import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
-import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_accounting_api.dart';
 import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_pot_api.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_confirm_request_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_request_request_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_request_response_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
-import 'package:pot_g/app/modules/chat/domain/exceptions/accounting_confirm_exception.dart';
-import 'package:pot_g/app/modules/chat/data/models/confirm_departure_time_request_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/confirm_departure_time_response_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/kick_user_response_model.dart';
-import 'package:pot_g/app/modules/chat/data/models/leave_pot_response_model.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
-import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
-import 'package:pot_g/app/modules/chat/domain/exceptions/accounting_request_exception.dart';
-import 'package:pot_g/app/modules/chat/domain/exceptions/departure_time_exception.dart';
-import 'package:pot_g/app/modules/chat/domain/exceptions/kick_user_exception.dart';
-import 'package:pot_g/app/modules/chat/domain/exceptions/leave_pot_exception.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_info_repository.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
 import 'package:pot_g/app/modules/socket/data/data_sources/websocket.dart';
@@ -33,9 +17,8 @@ import 'package:pot_g/app/modules/socket/data/models/pot_events/user_leave_v1_ev
 class WebsocketPotInfoRepository implements PotInfoRepository {
   final PotGSocket _socket;
   final ChatPotApi _api;
-  final ChatAccountingApi _accountingApi;
 
-  WebsocketPotInfoRepository(this._socket, this._api, this._accountingApi);
+  WebsocketPotInfoRepository(this._socket, this._api);
 
   @override
   Stream<PotInfoEntity> getPotInfoStream(PotIdEntity pot) async* {
@@ -55,157 +38,5 @@ class WebsocketPotInfoRepository implements PotInfoRepository {
         .map((e) => e.body)
         .where((e) => e.potPk == pot.id)
         .asyncMap((e) => _api.getPotInfo(pot.id));
-  }
-
-  @override
-  Future<void> setDepartureTime(PotInfoEntity pot, DateTime date) async {
-    try {
-      final result = await _api.confirmDepartureTime(
-        pot.id,
-        ConfirmDepartureTimeRequestModel(departureTime: date),
-      );
-      switch (result.result) {
-        case PotDepartureTimeResult.ok:
-          return;
-        case PotDepartureTimeResult.notAHost:
-          throw DepartureTimeException.notAHost();
-        case PotDepartureTimeResult.afterDeparture:
-          throw DepartureTimeException.afterDeparture();
-        case PotDepartureTimeResult.beforeNow:
-          throw DepartureTimeException.beforeNow();
-        case PotDepartureTimeResult.potNotExist:
-          throw DepartureTimeException.potNotExist();
-        case PotDepartureTimeResult.potAlreadyClosed:
-          throw DepartureTimeException.potAlreadyClosed();
-      }
-    } on DioException catch (e) {
-      throw DepartureTimeException.networkError(
-        e.message ?? e.error.toString(),
-      );
-    }
-  }
-
-  @override
-  Future<void> kickUser(PotInfoEntity pot, PotUserEntity user) async {
-    try {
-      final result = await _api.kickUser(pot.id, user.id);
-      switch (result.result) {
-        case KickUserResult.ok:
-          return;
-        case KickUserResult.notAHost:
-          throw KickUserException.notAHost();
-        case KickUserResult.notAParticipant:
-          throw KickUserException.notAParticipant();
-        case KickUserResult.userNotInPot:
-          throw KickUserException.userNotInPot();
-        case KickUserResult.afterDepartureConfirmed:
-          throw KickUserException.afterDepartureConfirmed();
-        case KickUserResult.notYetPaymentConfirmed:
-          throw KickUserException.notYetPaymentConfirmed();
-        case KickUserResult.potNotExist:
-          throw KickUserException.potNotExist();
-        case KickUserResult.potAlreadyClosed:
-          throw KickUserException.potAlreadyClosed();
-      }
-    } on DioException catch (e) {
-      throw KickUserException.networkError(e.message ?? e.error.toString());
-    }
-  }
-
-  @override
-  Future<void> leavePot(PotInfoEntity pot) async {
-    try {
-      final result = await _api.leavePot(pot.id);
-      switch (result.result) {
-        case LeavePotResult.ok:
-          return;
-        case LeavePotResult.afterDepartureConfirmed:
-          throw LeavePotException.afterDepartureConfirmed();
-        case LeavePotResult.notYetPaymentConfirmed:
-          throw LeavePotException.notYetPaymentConfirmed();
-        case LeavePotResult.notYetPaymentCompleted:
-          throw LeavePotException.notYetPaymentCompleted();
-        case LeavePotResult.potNotExist:
-          throw LeavePotException.potNotExist();
-        case LeavePotResult.potAlreadyClosed:
-          throw LeavePotException.potAlreadyClosed();
-      }
-    } on DioException catch (e) {
-      throw LeavePotException.networkError(e.message ?? e.error.toString());
-    }
-  }
-
-  @override
-  Future<void> accounting(
-    PotInfoEntity pot,
-    int amount,
-    List<PotUserEntity> targets,
-  ) async {
-    try {
-      final result = await _accountingApi.requestAccounting(
-        pot.id,
-        AccountingRequestRequestModel(
-          totalCost: amount,
-          costPerUser: amount ~/ (targets.length + 1),
-          accountInfo: AccountInfo(useExistInfo: true),
-          requestedUser: targets.map((e) => e.id).toList(),
-        ),
-      );
-      switch (result.result) {
-        case AccountingResult.ok:
-          return;
-        case AccountingResult.alreadyRequested:
-          throw AccountingRequestException.alreadyRequested();
-        case AccountingResult.accountInfoNotSet:
-          throw AccountingRequestException.accountInfoNotSet();
-        case AccountingResult.costCannotBeNegative:
-          throw AccountingRequestException.costCannotBeNegative();
-        case AccountingResult.costPerUserMismatch:
-          throw AccountingRequestException.costPerUserMismatch();
-        case AccountingResult.beforeDeparture:
-          throw AccountingRequestException.beforeDeparture();
-        case AccountingResult.notAParticipant:
-          throw AccountingRequestException.notAParticipant();
-        case AccountingResult.potNotExist:
-          throw AccountingRequestException.potNotExist();
-        case AccountingResult.potAlreadyClosed:
-          throw AccountingRequestException.potAlreadyClosed();
-      }
-    } on DioException catch (e) {
-      throw AccountingRequestException.networkError(
-        e.message ?? e.error.toString(),
-      );
-    }
-  }
-
-  @override
-  Future<void> confirmAccounting(
-    PotInfoEntity pot,
-    List<AccountingResultModel> accountingResults,
-  ) async {
-    try {
-      final result = await _accountingApi.confirmAccounting(
-        pot.id,
-        AccountingConfirmRequestModel(accountingResults: accountingResults),
-      );
-      switch (result.result) {
-        case 'OK':
-          return;
-        case 'NotYetRequested':
-          throw AccountingConfirmException.notYetRequested();
-        case 'NotAccountingRequester':
-          throw AccountingConfirmException.notAccountingRequester();
-        case 'PotNotExist':
-          throw AccountingConfirmException.potNotExist();
-        case 'PotAlreadyClosed':
-          throw AccountingConfirmException.potAlreadyClosed();
-        default:
-          throw AccountingConfirmException.networkError(result.result);
-      }
-    } on DioException catch (e) {
-      throw AccountingConfirmException.networkError(
-        e.message ?? e.error.toString(),
-      );
-    }
   }
 }

--- a/lib/app/modules/chat/domain/entities/accounting_result_entity.dart
+++ b/lib/app/modules/chat/domain/entities/accounting_result_entity.dart
@@ -1,0 +1,9 @@
+class AccountingResultEntity {
+  const AccountingResultEntity({
+    required this.userPk,
+    required this.accountingDone,
+  });
+
+  final String userPk;
+  final bool accountingDone;
+}

--- a/lib/app/modules/chat/domain/entities/pot_accounting_info_entity.dart
+++ b/lib/app/modules/chat/domain/entities/pot_accounting_info_entity.dart
@@ -1,4 +1,4 @@
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 
 abstract class PotAccountingInfoEntity {
   String? get requestingUser;
@@ -6,5 +6,5 @@ abstract class PotAccountingInfoEntity {
   int? get costPerUser;
   String? get bankName;
   String? get bankAccount;
-  List<AccountingResultModel> get accountingResults;
+  List<AccountingResultEntity> get accountingResults;
 }

--- a/lib/app/modules/chat/domain/repositories/pot_accounting_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/pot_accounting_repository.dart
@@ -1,4 +1,4 @@
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 
@@ -10,6 +10,6 @@ abstract class PotAccountingRepository {
   );
   Future<void> confirmAccounting(
     PotInfoEntity pot,
-    List<AccountingResultModel> accountingResults,
+    List<AccountingResultEntity> accountingResults,
   );
 }

--- a/lib/app/modules/chat/domain/repositories/pot_accounting_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/pot_accounting_repository.dart
@@ -1,0 +1,15 @@
+import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+
+abstract class PotAccountingRepository {
+  Future<void> accounting(
+    PotInfoEntity pot,
+    int amount,
+    List<PotUserEntity> targets,
+  );
+  Future<void> confirmAccounting(
+    PotInfoEntity pot,
+    List<AccountingResultModel> accountingResults,
+  );
+}

--- a/lib/app/modules/chat/domain/repositories/pot_action_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/pot_action_repository.dart
@@ -1,0 +1,8 @@
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+
+abstract class PotActionRepository {
+  Future<void> setDepartureTime(PotInfoEntity pot, DateTime date);
+  Future<void> leavePot(PotInfoEntity pot);
+  Future<void> kickUser(PotInfoEntity pot, PotUserEntity user);
+}

--- a/lib/app/modules/chat/domain/repositories/pot_info_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/pot_info_repository.dart
@@ -1,20 +1,6 @@
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
-import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
 
 abstract class PotInfoRepository {
   Stream<PotInfoEntity> getPotInfoStream(PotIdEntity pot);
-  Future<void> setDepartureTime(PotInfoEntity pot, DateTime date);
-  Future<void> leavePot(PotInfoEntity pot);
-  Future<void> kickUser(PotInfoEntity pot, PotUserEntity user);
-  Future<void> accounting(
-    PotInfoEntity pot,
-    int amount,
-    List<PotUserEntity> targets,
-  );
-  Future<void> confirmAccounting(
-    PotInfoEntity pot,
-    List<AccountingResultModel> accountingResults,
-  );
 }

--- a/lib/app/modules/chat/presentation/bloc/accounting_confirm_cubit.dart
+++ b/lib/app/modules/chat/presentation/bloc/accounting_confirm_cubit.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 
 part 'accounting_confirm_cubit.freezed.dart';
 
@@ -9,7 +9,7 @@ part 'accounting_confirm_cubit.freezed.dart';
 class AccountingConfirmCubit extends Cubit<AccountingConfirmState> {
   AccountingConfirmCubit() : super(const AccountingConfirmState());
 
-  void loadInitialState(List<AccountingResultModel> accountingResults) {
+  void loadInitialState(List<AccountingResultEntity> accountingResults) {
     final Map<String, bool> userStates = {};
     for (final result in accountingResults) {
       userStates[result.userPk] = result.accountingDone;
@@ -24,10 +24,10 @@ class AccountingConfirmCubit extends Cubit<AccountingConfirmState> {
     emit(AccountingConfirmState(userStates: newStates));
   }
 
-  List<AccountingResultModel> getAccountingResults() {
+  List<AccountingResultEntity> getAccountingResults() {
     return state.userStates.entries
         .map(
-          (entry) => AccountingResultModel(
+          (entry) => AccountingResultEntity(
             userPk: entry.key,
             accountingDone: entry.value,
           ),
@@ -43,7 +43,7 @@ sealed class AccountingConfirmState with _$AccountingConfirmState {
     @Default({}) Map<String, bool> userStates,
   }) = _AccountingConfirmState;
 
-  bool hasChanges(List<AccountingResultModel> originalResults) {
+  bool hasChanges(List<AccountingResultEntity> originalResults) {
     if (userStates.isEmpty) return false;
 
     for (final original in originalResults) {
@@ -55,4 +55,3 @@ sealed class AccountingConfirmState with _$AccountingConfirmState {
     return false;
   }
 }
-

--- a/lib/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/repositories/pot_accounting_repository.dart';
+
+part 'pot_accounting_bloc.freezed.dart';
+
+@injectable
+class PotAccountingBloc extends Bloc<PotAccountingEvent, PotAccountingState> {
+  final PotAccountingRepository _repository;
+
+  PotAccountingBloc(this._repository)
+    : super(const PotAccountingState.initial()) {
+    on<_RequestAccounting>(_onRequestAccounting);
+    on<_ConfirmAccounting>(_onConfirmAccounting);
+  }
+
+  Future<void> _onRequestAccounting(
+    _RequestAccounting event,
+    Emitter<PotAccountingState> emit,
+  ) async {
+    emit(const PotAccountingState.loading());
+    try {
+      await _repository.accounting(event.pot, event.amount, event.targets);
+      emit(const PotAccountingState.requestSuccess());
+    } catch (e) {
+      emit(PotAccountingState.error(e.toString()));
+    }
+  }
+
+  Future<void> _onConfirmAccounting(
+    _ConfirmAccounting event,
+    Emitter<PotAccountingState> emit,
+  ) async {
+    emit(const PotAccountingState.loading());
+    try {
+      await _repository.confirmAccounting(event.pot, event.accountingResults);
+      emit(const PotAccountingState.confirmSuccess());
+    } catch (e) {
+      emit(PotAccountingState.error(e.toString()));
+    }
+  }
+}
+
+@freezed
+sealed class PotAccountingEvent with _$PotAccountingEvent {
+  const factory PotAccountingEvent.requestAccounting(
+    PotInfoEntity pot,
+    int amount,
+    List<PotUserEntity> targets,
+  ) = _RequestAccounting;
+  const factory PotAccountingEvent.confirmAccounting(
+    PotInfoEntity pot,
+    List<AccountingResultModel> accountingResults,
+  ) = _ConfirmAccounting;
+}
+
+@freezed
+sealed class PotAccountingState with _$PotAccountingState {
+  const PotAccountingState._();
+  const factory PotAccountingState.initial() = _Initial;
+  const factory PotAccountingState.loading() = _Loading;
+  const factory PotAccountingState.requestSuccess() = _RequestSuccess;
+  const factory PotAccountingState.confirmSuccess() = _ConfirmSuccess;
+  const factory PotAccountingState.error(String message) = _Error;
+
+  bool get isLoading => switch (this) {
+    _Loading() => true,
+    _ => false,
+  };
+  String? get error => switch (this) {
+    _Error(:final message) => message,
+    _ => null,
+  };
+}

--- a/lib/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/accounting_result_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_accounting_repository.dart';
@@ -54,7 +54,7 @@ sealed class PotAccountingEvent with _$PotAccountingEvent {
   ) = _RequestAccounting;
   const factory PotAccountingEvent.confirmAccounting(
     PotInfoEntity pot,
-    List<AccountingResultModel> accountingResults,
+    List<AccountingResultEntity> accountingResults,
   ) = _ConfirmAccounting;
 }
 

--- a/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/repositories/pot_action_repository.dart';
+
+part 'pot_action_bloc.freezed.dart';
+
+@injectable
+class PotActionBloc extends Bloc<PotActionEvent, PotActionState> {
+  final PotActionRepository _repository;
+
+  PotActionBloc(this._repository) : super(const PotActionState.initial()) {
+    on<_SetDepartureTime>(_onSetDepartureTime);
+    on<_LeavePot>(_onLeavePot);
+    on<_KickUser>(_onKickUser);
+  }
+
+  Future<void> _onSetDepartureTime(
+    _SetDepartureTime event,
+    Emitter<PotActionState> emit,
+  ) async {
+    emit(const PotActionState.loading());
+    try {
+      await _repository.setDepartureTime(event.pot, event.date);
+      emit(const PotActionState.success());
+    } catch (e) {
+      emit(PotActionState.error(e.toString()));
+    }
+  }
+
+  Future<void> _onLeavePot(
+    _LeavePot event,
+    Emitter<PotActionState> emit,
+  ) async {
+    emit(const PotActionState.loading());
+    try {
+      await _repository.leavePot(event.pot);
+      emit(const PotActionState.success());
+    } catch (e) {
+      emit(PotActionState.error(e.toString()));
+    }
+  }
+
+  Future<void> _onKickUser(
+    _KickUser event,
+    Emitter<PotActionState> emit,
+  ) async {
+    emit(const PotActionState.loading());
+    try {
+      await _repository.kickUser(event.pot, event.user);
+      emit(const PotActionState.success());
+    } catch (e) {
+      emit(PotActionState.error(e.toString()));
+    }
+  }
+}
+
+@freezed
+sealed class PotActionEvent with _$PotActionEvent {
+  const factory PotActionEvent.setDepartureTime(
+    PotInfoEntity pot,
+    DateTime date,
+  ) = _SetDepartureTime;
+  const factory PotActionEvent.leavePot(PotInfoEntity pot) = _LeavePot;
+  const factory PotActionEvent.kickUser(PotInfoEntity pot, PotUserEntity user) =
+      _KickUser;
+}
+
+@freezed
+sealed class PotActionState with _$PotActionState {
+  const PotActionState._();
+  const factory PotActionState.initial() = _Initial;
+  const factory PotActionState.loading() = _Loading;
+  const factory PotActionState.success() = _Success;
+  const factory PotActionState.error(String message) = _Error;
+
+  bool get isLoading => switch (this) {
+    _Loading() => true,
+    _ => false,
+  };
+  String? get error => switch (this) {
+    _Error(:final message) => message,
+    _ => null,
+  };
+}

--- a/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
@@ -1,9 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:pot_g/app/modules/chat/data/models/accounting_result_model.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
-import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/enums/pot_status.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_info_repository.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
@@ -16,11 +14,6 @@ class PotInfoBloc extends Bloc<PotInfoEvent, PotInfoState> {
 
   PotInfoBloc(this._repository) : super(const PotInfoState.loading()) {
     on<_Init>(_onInit);
-    on<_SetDepartureTime>(_onSetDepartureTime);
-    on<_LeavePot>(_onLeavePot);
-    on<_KickUser>(_onKickUser);
-    on<_Accounting>(_onAccounting);
-    on<_ConfirmAccounting>(_onConfirmAccounting);
   }
 
   Future<void> _onInit(_Init event, Emitter<PotInfoState> emit) async {
@@ -30,86 +23,11 @@ class PotInfoBloc extends Bloc<PotInfoEvent, PotInfoState> {
       onError: (error, stackTrace) => PotInfoState.error(error.toString()),
     );
   }
-
-  Future<void> _onSetDepartureTime(
-    _SetDepartureTime event,
-    Emitter<PotInfoState> emit,
-  ) async {
-    if (state.pot == null) return;
-    try {
-      await _repository.setDepartureTime(state.pot!, event.date);
-    } catch (e) {
-      emit(PotInfoState.error(e.toString()));
-    }
-  }
-
-  Future<void> _onLeavePot(_LeavePot event, Emitter<PotInfoState> emit) async {
-    if (state.pot == null) return;
-    try {
-      await _repository.leavePot(state.pot!);
-    } catch (e) {
-      emit(PotInfoState.error(e.toString()));
-    }
-  }
-
-  Future<void> _onKickUser(_KickUser event, Emitter<PotInfoState> emit) async {
-    if (state.pot == null) return;
-    try {
-      await _repository.kickUser(state.pot!, event.user);
-    } catch (e) {
-      emit(PotInfoState.error(e.toString()));
-    }
-  }
-
-  Future<void> _onAccounting(
-    _Accounting event,
-    Emitter<PotInfoState> emit,
-  ) async {
-    if (state.pot == null) return;
-    final pot = state.pot!;
-    try {
-      emit(const PotInfoState.loading());
-      await _repository.accounting(pot, event.amount, event.targets);
-      emit(const PotInfoState.accountingSuccess());
-    } catch (e) {
-      emit(PotInfoState.error(e.toString()));
-    } finally {
-      emit(PotInfoState.loaded(pot));
-    }
-  }
-
-  Future<void> _onConfirmAccounting(
-    _ConfirmAccounting event,
-    Emitter<PotInfoState> emit,
-  ) async {
-    if (state.pot == null) return;
-    final pot = state.pot!;
-    try {
-      emit(const PotInfoState.loading());
-      await _repository.confirmAccounting(pot, event.accountingResults);
-      emit(const PotInfoState.accountingConfirmSuccess());
-    } catch (e) {
-      emit(PotInfoState.error(e.toString()));
-    } finally {
-      emit(PotInfoState.loaded(pot));
-    }
-  }
 }
 
 @freezed
 sealed class PotInfoEvent with _$PotInfoEvent {
   const factory PotInfoEvent.init(PotIdEntity pot) = _Init;
-  const factory PotInfoEvent.setDepartureTime(DateTime date) =
-      _SetDepartureTime;
-  const factory PotInfoEvent.leavePot() = _LeavePot;
-  const factory PotInfoEvent.kickUser(PotUserEntity user) = _KickUser;
-  const factory PotInfoEvent.accounting(
-    int amount,
-    List<PotUserEntity> targets,
-  ) = _Accounting;
-  const factory PotInfoEvent.confirmAccounting(
-    List<AccountingResultModel> accountingResults,
-  ) = _ConfirmAccounting;
 }
 
 @freezed
@@ -117,9 +35,6 @@ sealed class PotInfoState with _$PotInfoState {
   const PotInfoState._();
   const factory PotInfoState.loading() = _Loading;
   const factory PotInfoState.loaded(PotInfoEntity pot) = _Loaded;
-  const factory PotInfoState.accountingSuccess() = AccountingSuccess;
-  const factory PotInfoState.accountingConfirmSuccess() =
-      AccountingConfirmSuccess;
   const factory PotInfoState.error(String message) = _Error;
 
   PotInfoEntity? get pot => switch (this) {

--- a/lib/app/modules/chat/presentation/pages/accounting_page.dart
+++ b/lib/app/modules/chat/presentation/pages/accounting_page.dart
@@ -7,7 +7,7 @@ import 'package:pot_g/app/modules/auth/presentation/bloc/auth_bloc.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/accounting_cubit.dart';
-import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_profile_image.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/formatters/thousand_won_formatter.dart';
@@ -32,26 +32,21 @@ class AccountingPage extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create:
-              (context) =>
-                  sl<AccountingCubit>()..loadTargets(
-                    pot.usersInfo.users.where(
-                      (u) => u.isInPot && u.id != AuthBloc.userOf(context)?.id,
-                    ),
-                  ),
+          create: (context) => sl<AccountingCubit>()
+            ..loadTargets(
+              pot.usersInfo.users.where(
+                (u) => u.isInPot && u.id != AuthBloc.userOf(context)?.id,
+              ),
+            ),
         ),
-        BlocProvider(
-          create: (context) => sl<PotInfoBloc>()..add(PotInfoEvent.init(pot)),
-        ),
+        BlocProvider(create: (context) => sl<PotAccountingBloc>()),
       ],
-      child: BlocListener<PotInfoBloc, PotInfoState>(
+      child: BlocListener<PotAccountingBloc, PotAccountingState>(
         listener: (context, state) {
-          if (state is AccountingSuccess) {
-            context.router.pop();
-          }
-          if (state.error != null) {
-            context.showToast(state.error!);
-          }
+          state.mapOrNull(
+            requestSuccess: (_) => context.router.pop(),
+            error: (e) => context.showToast(e.message),
+          );
         },
         child: _Layout(pot: pot),
       ),
@@ -92,18 +87,19 @@ class _Layout extends StatelessWidget {
                     BlocBuilder<AccountingCubit, AccountingState>(
                       builder: (context, state) {
                         return PotButton(
-                          onPressed:
-                              state.valid && hasBank
-                                  ? () {
-                                    final bloc = context.read<PotInfoBloc>();
-                                    bloc.add(
-                                      PotInfoEvent.accounting(
-                                        state.amount!,
-                                        state.targets!.toList(),
-                                      ),
-                                    );
-                                  }
-                                  : null,
+                          onPressed: state.valid && hasBank
+                              ? () {
+                                  final bloc = context
+                                      .read<PotAccountingBloc>();
+                                  bloc.add(
+                                    PotAccountingEvent.requestAccounting(
+                                      pot,
+                                      state.amount!,
+                                      state.targets!.toList(),
+                                    ),
+                                  );
+                                }
+                              : null,
                           variant: PotButtonVariant.emphasized,
                           child: Text(context.dutch.action),
                         );
@@ -168,8 +164,8 @@ class _DefaultNotRegistered extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         PotButton(
-          onPressed:
-              () => AccountNumberSettingsPage.showAccountNumberSetting(context),
+          onPressed: () =>
+              AccountNumberSettingsPage.showAccountNumberSetting(context),
           variant: PotButtonVariant.emphasized,
           prefixIcon: Assets.icons.dollar.svg(
             width: 24,
@@ -218,10 +214,8 @@ class _BankAccount extends StatelessWidget {
             ),
             Spacer(),
             PotButton(
-              onPressed:
-                  () => AccountNumberSettingsPage.showAccountNumberSetting(
-                    context,
-                  ),
+              onPressed: () =>
+                  AccountNumberSettingsPage.showAccountNumberSetting(context),
               size: PotButtonSize.small,
               child: Text(context.dutch.fields.account.action),
             ),
@@ -239,10 +233,9 @@ class _SettlementTargets extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final users =
-        pot.usersInfo.users
-            .where((u) => u.isInPot && u.id != AuthBloc.userOf(context)?.id)
-            .toList();
+    final users = pot.usersInfo.users
+        .where((u) => u.isInPot && u.id != AuthBloc.userOf(context)?.id)
+        .toList();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -257,16 +250,15 @@ class _SettlementTargets extends StatelessWidget {
             border: Border.all(color: Palette.borderGrey),
           ),
           child: Column(
-            children:
-                users
-                    .expandIndexed(
-                      (index, user) => [
-                        if (index != 0)
-                          Container(height: 1, color: Palette.borderGrey),
-                        _card(user),
-                      ],
-                    )
-                    .toList(),
+            children: users
+                .expandIndexed(
+                  (index, user) => [
+                    if (index != 0)
+                      Container(height: 1, color: Palette.borderGrey),
+                    _card(user),
+                  ],
+                )
+                .toList(),
           ),
         ),
       ],

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -11,6 +11,8 @@ import 'package:pot_g/app/modules/chat/domain/entities/chat_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/enums/fofo_action_button_type.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/extensions/pot_user_extension.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_bubble.dart';
@@ -49,20 +51,28 @@ class ChatRoomPage extends StatelessWidget with LogPageStateless {
         BlocProvider(
           create: (context) => sl<PotInfoBloc>()..add(PotInfoEvent.init(pot)),
         ),
+        BlocProvider(create: (context) => sl<PotActionBloc>()),
+        BlocProvider(create: (context) => sl<PotAccountingBloc>()),
       ],
       child: MultiBlocListener(
         listeners: [
           BlocListener<PotInfoBloc, PotInfoState>(
-            listenWhen:
-                (prev, curr) =>
-                    prev.pot?.id != curr.pot?.id && curr.pot != null,
-            listener:
-                (context, state) =>
-                    context.read<ChatBloc>().add(ChatInit(state.pot!)),
+            listenWhen: (prev, curr) =>
+                prev.pot?.id != curr.pot?.id && curr.pot != null,
+            listener: (context, state) =>
+                context.read<ChatBloc>().add(ChatInit(state.pot!)),
           ),
           BlocListener<ChatBloc, ChatState>(
-            listenWhen:
-                (prev, curr) => prev.error != curr.error && curr.error != null,
+            listenWhen: (prev, curr) =>
+                prev.error != curr.error && curr.error != null,
+            listener: (context, state) => context.showToast(state.error!),
+          ),
+          BlocListener<PotActionBloc, PotActionState>(
+            listenWhen: (prev, curr) => curr.error != null,
+            listener: (context, state) => context.showToast(state.error!),
+          ),
+          BlocListener<PotAccountingBloc, PotAccountingState>(
+            listenWhen: (prev, curr) => curr.error != null,
             listener: (context, state) => context.showToast(state.error!),
           ),
         ],
@@ -194,7 +204,9 @@ class _SetDepartureTimeButton extends StatelessWidget {
     if (result2 != OkCancelResult.ok) return;
     L.c('confirmDepartureTime', from: 'departureTimeConfirm');
     if (!context.mounted) return;
-    context.read<PotInfoBloc>().add(PotInfoEvent.setDepartureTime(date));
+    context.read<PotActionBloc>().add(
+      PotActionEvent.setDepartureTime(pot, date),
+    );
   }
 
   @override
@@ -245,8 +257,9 @@ class _ChatListState extends State<_ChatList> {
       builder: (context, state) {
         bool isLast(int index) {
           final chat = state.chats[index];
-          final nextChat =
-              index == state.chats.length - 1 ? null : state.chats[index + 1];
+          final nextChat = index == state.chats.length - 1
+              ? null
+              : state.chats[index + 1];
           if (chat is! ChatEntity || nextChat is! ChatEntity) {
             return true;
           }
@@ -257,8 +270,8 @@ class _ChatListState extends State<_ChatList> {
           controller: _controller,
           reverse: true,
           padding: const EdgeInsets.all(12) - EdgeInsets.only(right: 6),
-          separatorBuilder:
-              (context, index) => SizedBox(height: isLast(index) ? 12 : 6),
+          separatorBuilder: (context, index) =>
+              SizedBox(height: isLast(index) ? 12 : 6),
           itemBuilder: (context, index) => _buildItem(context, index, state),
           itemCount: state.chats.length + (state.isLoading ? 1 : 0),
         );
@@ -269,8 +282,9 @@ class _ChatListState extends State<_ChatList> {
   Widget _buildItem(BuildContext context, int index, ChatState state) {
     bool isFirst(int index) {
       final chat = state.chats[index];
-      final nextChat =
-          index == state.chats.length - 1 ? null : state.chats[index + 1];
+      final nextChat = index == state.chats.length - 1
+          ? null
+          : state.chats[index + 1];
       if (chat is! ChatEntity || nextChat is! ChatEntity) {
         return true;
       }

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/enums/pot_status.dart';
-import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_accounting.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_info.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_users.dart';
@@ -76,6 +76,6 @@ class ChatRoomDrawer extends StatelessWidget {
     );
     if (result != OkCancelResult.ok) return;
     if (!context.mounted) return;
-    context.read<PotInfoBloc>().add(PotInfoEvent.leavePot());
+    context.read<PotActionBloc>().add(PotActionEvent.leavePot(pot));
   }
 }

--- a/lib/app/modules/chat/presentation/widgets/pot_accounting.dart
+++ b/lib/app/modules/chat/presentation/widgets/pot_accounting.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:pot_g/app/di/locator.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/accounting_confirm_cubit.dart';
-import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/extensions/pot_user_extension.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_user.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
@@ -31,23 +31,18 @@ class PotAccounting extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create:
-              (context) =>
-                  sl<AccountingConfirmCubit>()
-                    ..loadInitialState(pot.accountingInfo.accountingResults),
+          create: (context) =>
+              sl<AccountingConfirmCubit>()
+                ..loadInitialState(pot.accountingInfo.accountingResults),
         ),
-        BlocProvider(
-          create: (context) => sl<PotInfoBloc>()..add(PotInfoEvent.init(pot)),
-        ),
+        BlocProvider(create: (context) => sl<PotAccountingBloc>()),
       ],
-      child: BlocListener<PotInfoBloc, PotInfoState>(
+      child: BlocListener<PotAccountingBloc, PotAccountingState>(
         listener: (context, state) {
-          if (state is AccountingConfirmSuccess) {
-            Scaffold.of(context).closeEndDrawer();
-          }
-          if (state.error != null) {
-            context.showToast(state.error!);
-          }
+          state.mapOrNull(
+            confirmSuccess: (_) => Scaffold.of(context).closeEndDrawer(),
+            error: (e) => context.showToast(e.message),
+          );
         },
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -104,10 +99,9 @@ class PotAccounting extends StatelessWidget {
                       user: e,
                       pot: pot,
                       payStatus: isDone ? PayStatus.done : PayStatus.notPaid,
-                      onPay:
-                          (value) => context
-                              .read<AccountingConfirmCubit>()
-                              .toggleUser(e.id),
+                      onPay: (value) => context
+                          .read<AccountingConfirmCubit>()
+                          .toggleUser(e.id),
                     );
                   },
                 ),
@@ -125,12 +119,11 @@ class PotAccounting extends StatelessWidget {
                   children: [
                     PotButton(
                       onPressed: () {
-                        final results =
-                            context
-                                .read<AccountingConfirmCubit>()
-                                .getAccountingResults();
-                        context.read<PotInfoBloc>().add(
-                          PotInfoEvent.confirmAccounting(results),
+                        final results = context
+                            .read<AccountingConfirmCubit>()
+                            .getAccountingResults();
+                        context.read<PotAccountingBloc>().add(
+                          PotAccountingEvent.confirmAccounting(pot, results),
                         );
                       },
                       variant: PotButtonVariant.emphasized,

--- a/lib/app/modules/chat/presentation/widgets/pot_users.dart
+++ b/lib/app/modules/chat/presentation/widgets/pot_users.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_user_entity.dart';
-import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/extensions/pot_user_extension.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_user.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
@@ -44,16 +44,15 @@ class PotUsers extends StatelessWidget {
             if (index != 0) const SizedBox(height: 8),
             PotUser(
               user: e,
-              onKick:
-                  me?.isHost ?? false
-                      ? () {
-                        L.c(
-                          'kick',
-                          properties: {'userId': e.id, 'roomId': pot.id},
-                        );
-                        _kickUser(context, e);
-                      }
-                      : null,
+              onKick: me?.isHost ?? false
+                  ? () {
+                      L.c(
+                        'kick',
+                        properties: {'userId': e.id, 'roomId': pot.id},
+                      );
+                      _kickUser(context, e);
+                    }
+                  : null,
               pot: pot,
             ),
           ],
@@ -85,6 +84,6 @@ class PotUsers extends StatelessWidget {
     );
     if (result != OkCancelResult.ok) return;
     if (!context.mounted) return;
-    context.read<PotInfoBloc>().add(PotInfoEvent.kickUser(user));
+    context.read<PotActionBloc>().add(PotActionEvent.kickUser(pot, user));
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -881,26 +881,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lean_builder:
     dependency: transitive
     description:
@@ -1382,26 +1382,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.11"
   time:
     dependency: transitive
     description:
@@ -1542,10 +1542,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1651,5 +1651,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
- **chore: change flutter version**
- **refactor: separate pot info bloc**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 출발시간 설정, 나가기, 강퇴, 정산 요청/확정이 각각 전용 흐름(별도 블록)으로 분리되어 로딩/성공/오류 상태가 명확해졌습니다.
  - 정산 관련 타입이 강타입(엔터티/열거형)으로 개선되어 결과 처리 일관성이 향상되었습니다.
- Refactor
  - PotInfo의 액션·정산 책임을 전용 리포지토리/블록/인터페이스로 분리하고 실시간 Pot 정보 스트림은 유지했습니다.
  - UI 페이지/위젯들이 신규 블록들(PotAction/PotAccounting)으로 전환되었습니다.
- Chores
  - CI 플러터 액션을 3.35.5로 업데이트하고 SDK 제약을 ^3.9.0으로 상향 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->