### PR TITLE
fix: prevent accounting before confirmed

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -247,6 +247,7 @@
       }
     },
     "accounting": {
+      "before_confirm": "You cannot request accounting before confirming the departure time",
       "dutch": {
         "title": "Dutch Pay",
         "fields": {

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -244,6 +244,7 @@
       }
     },
     "accounting": {
+      "before_confirm": "출발 시간을 확정하지 않아 정산을 요청할 수 없습니다",
       "dutch": {
         "title": "정산하기",
         "fields": {

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -138,6 +138,10 @@ class _AccountingButton extends StatelessWidget {
     BuildContext context,
     PotInfoEntity pot,
   ) async {
+    if (pot.departureTime == null) {
+      context.showToast(context.t.chat_room.accounting.before_confirm);
+      return;
+    }
     await AccountingRoute(pot: pot).push(context);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 채팅방의 정산 버튼에 보호 로직을 추가하여, 출발 시간이 확정되지 않으면 정산 화면으로 이동하지 않도록 변경했습니다.
  - 해당 상황에서 안내 토스트 메시지를 표시해 잘못된 진행을 방지하고 명확한 피드백을 제공합니다.

- **New Features**
  - “출발 시간을 확정하지 않아 정산을 요청할 수 없습니다” 안내 문구를 한국어/영어로 추가해 다국어 안내를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->