### PR TITLE
feat: pot id based navigation, refresh list after member change

### DIFF
--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -26,7 +26,7 @@ import 'package:pot_g/app/modules/common/presentation/widgets/error_cover.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/general_dialog.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_icon_button.dart';
-import 'package:pot_g/app/modules/core/domain/entities/pot_detail_entity.dart';
+import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
 import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/app/values/palette.dart';
@@ -34,14 +34,20 @@ import 'package:pot_g/app/values/text_styles.dart';
 import 'package:pot_g/gen/assets.gen.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
+class _PotId implements PotIdEntity {
+  _PotId({@PathParam() required this.id});
+  @override
+  final String id;
+}
+
 @RoutePage()
 class ChatRoomPage extends StatelessWidget with LogPageStateless {
-  const ChatRoomPage({super.key, required this.pot});
+  const ChatRoomPage({super.key, required this.id});
 
   @override
   String get pageName => 'chatRoom';
 
-  final PotDetailEntity pot;
+  final String id;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +55,8 @@ class ChatRoomPage extends StatelessWidget with LogPageStateless {
       providers: [
         BlocProvider(create: (context) => sl<ChatBloc>()),
         BlocProvider(
-          create: (context) => sl<PotInfoBloc>()..add(PotInfoEvent.init(pot)),
+          create: (context) =>
+              sl<PotInfoBloc>()..add(PotInfoEvent.init(_PotId(id: id))),
         ),
         BlocProvider(create: (context) => sl<PotActionBloc>()),
         BlocProvider(create: (context) => sl<PotAccountingBloc>()),

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -35,14 +35,14 @@ import 'package:pot_g/gen/assets.gen.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
 class _PotId implements PotIdEntity {
-  _PotId({@PathParam() required this.id});
+  _PotId({required this.id});
   @override
   final String id;
 }
 
 @RoutePage()
 class ChatRoomPage extends StatelessWidget with LogPageStateless {
-  const ChatRoomPage({super.key, required this.id});
+  const ChatRoomPage({super.key, @PathParam() required this.id});
 
   @override
   String get pageName => 'chatRoom';

--- a/lib/app/modules/chat/presentation/widgets/chat_list_item.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list_item.dart
@@ -20,10 +20,12 @@ class ChatListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textColorTitle =
-        pot.status == PotStatus.archived ? Palette.grey : Palette.dark;
-    final textColorDescription =
-        pot.status == PotStatus.archived ? Palette.grey : Palette.textGrey;
+    final textColorTitle = pot.status == PotStatus.archived
+        ? Palette.grey
+        : Palette.dark;
+    final textColorDescription = pot.status == PotStatus.archived
+        ? Palette.grey
+        : Palette.textGrey;
 
     Widget field({required String label, required String value}) {
       return Row(
@@ -44,7 +46,7 @@ class ChatListItem extends StatelessWidget {
     return PotPressable(
       onTap: () {
         L.c('chatRoom', properties: {'name': pot.name});
-        ChatRoomRoute(pot: pot).push(context);
+        ChatRoomRoute(id: pot.id).push(context);
       },
       child: Container(
         padding:
@@ -70,32 +72,30 @@ class ChatListItem extends StatelessWidget {
           children: [
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children:
-                  [
-                    Text(
-                      '팟 정보',
-                      style: TextStyles.caption.copyWith(color: Palette.grey),
-                    ),
-                    field(label: '노선', value: pot.route.name),
-                    field(
-                      label: '날짜',
-                      value: DateFormat.yMd().add_E().format(pot.startsAt),
-                    ),
-                    field(
-                      label: '시간',
-                      value:
-                          pot.status == PotStatus.beforeConfirmed
-                              ? '${DateFormat.Hm().format(pot.startsAt)}~${DateFormat.Hm().format(pot.endsAt)}'
-                              : DateFormat.Hm().format(pot.startsAt),
-                    ),
-                    if (pot.status == PotStatus.waitAccounting ||
-                        pot.status == PotStatus.archived)
-                      field(
-                        label: '정산',
-                        value:
-                            '${NumberFormat('#,###').format(pot.accountingRequested)}원',
-                      ),
-                  ].intersperse(const SizedBox(height: 4)).toList(),
+              children: [
+                Text(
+                  '팟 정보',
+                  style: TextStyles.caption.copyWith(color: Palette.grey),
+                ),
+                field(label: '노선', value: pot.route.name),
+                field(
+                  label: '날짜',
+                  value: DateFormat.yMd().add_E().format(pot.startsAt),
+                ),
+                field(
+                  label: '시간',
+                  value: pot.status == PotStatus.beforeConfirmed
+                      ? '${DateFormat.Hm().format(pot.startsAt)}~${DateFormat.Hm().format(pot.endsAt)}'
+                      : DateFormat.Hm().format(pot.startsAt),
+                ),
+                if (pot.status == PotStatus.waitAccounting ||
+                    pot.status == PotStatus.archived)
+                  field(
+                    label: '정산',
+                    value:
+                        '${NumberFormat('#,###').format(pot.accountingRequested)}원',
+                  ),
+              ].intersperse(const SizedBox(height: 4)).toList(),
             ),
             Positioned(
               right: 0,

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -1,12 +1,15 @@
 import 'package:adaptive_dialog/adaptive_dialog.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/domain/enums/pot_status.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_accounting.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_info.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/pot_users.dart';
+import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_pressable.dart';
 import 'package:pot_g/app/values/palette.dart';
@@ -76,6 +79,19 @@ class ChatRoomDrawer extends StatelessWidget {
     );
     if (result != OkCancelResult.ok) return;
     if (!context.mounted) return;
-    context.read<PotActionBloc>().add(PotActionEvent.leavePot(pot));
+    final bloc = context.read<PotActionBloc>();
+    final blocker = bloc.stream.firstWhere(
+      (s) => !s.isLoading || s.error != null,
+    );
+    context.router.pop();
+    bloc.add(PotActionEvent.leavePot(pot));
+    final state = await blocker;
+    if (!context.mounted) return;
+    if (state.error != null) {
+      context.showToast(state.error!);
+      return;
+    }
+    context.router.pop();
+    context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
   }
 }

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -83,8 +83,6 @@ class ChatRoomDrawer extends StatelessWidget {
     final blocker = bloc.stream.firstWhere(
       (s) => !s.isLoading || s.error != null,
     );
-    final router = context.router;
-    router.pop();
     bloc.add(PotActionEvent.leavePot(pot));
     final state = await blocker;
     if (!context.mounted) return;
@@ -92,7 +90,9 @@ class ChatRoomDrawer extends StatelessWidget {
       context.showToast(state.error!);
       return;
     }
-    router.pop();
+    context.router
+      ..pop()
+      ..pop();
     context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
   }
 }

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -83,7 +83,8 @@ class ChatRoomDrawer extends StatelessWidget {
     final blocker = bloc.stream.firstWhere(
       (s) => !s.isLoading || s.error != null,
     );
-    context.router.pop();
+    final router = context.router;
+    router.pop();
     bloc.add(PotActionEvent.leavePot(pot));
     final state = await blocker;
     if (!context.mounted) return;
@@ -91,7 +92,7 @@ class ChatRoomDrawer extends StatelessWidget {
       context.showToast(state.error!);
       return;
     }
-    context.router.pop();
+    router.pop();
     context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
   }
 }

--- a/lib/app/modules/create/data/data_source/remote/create_pot_api.dart
+++ b/lib/app/modules/create/data/data_source/remote/create_pot_api.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/core/data/dio/pot_dio.dart';
 import 'package:pot_g/app/modules/create/data/model/create_pot_model.dart';
+import 'package:pot_g/app/modules/create/data/model/create_pot_result_model.dart';
 import 'package:retrofit/retrofit.dart';
 
 part 'create_pot_api.g.dart';
@@ -13,5 +14,5 @@ abstract class CreatePotApi {
   factory CreatePotApi(PotDio dio) = _CreatePotApi;
 
   @POST('create')
-  Future<String> createPot(@Body() CreatePotModel body);
+  Future<CreatePotResultModel> createPot(@Body() CreatePotModel body);
 }

--- a/lib/app/modules/create/data/model/create_pot_result_model.dart
+++ b/lib/app/modules/create/data/model/create_pot_result_model.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'create_pot_result_model.freezed.dart';
+part 'create_pot_result_model.g.dart';
+
+@Freezed(toJson: false)
+sealed class CreatePotResultModel with _$CreatePotResultModel {
+  const factory CreatePotResultModel({required String id}) =
+      _CreatePotResultModel;
+
+  factory CreatePotResultModel.fromJson(Map<String, dynamic> json) =>
+      _$CreatePotResultModelFromJson(json);
+}

--- a/lib/app/modules/create/data/repositories/rest_create_pot_repository.dart
+++ b/lib/app/modules/create/data/repositories/rest_create_pot_repository.dart
@@ -23,8 +23,7 @@ class RestCreatePotRepository implements CreatePotRepository {
       maxCount: maxCount,
     );
 
-    final String potId = await _api.createPot(createPotModel);
-
-    return potId;
+    final result = await _api.createPot(createPotModel);
+    return result.id;
   }
 }

--- a/lib/app/modules/create/presentation/bloc/create_pot_bloc.dart
+++ b/lib/app/modules/create/presentation/bloc/create_pot_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
@@ -18,14 +16,12 @@ class CreatePotBloc extends Bloc<CreatePotEvent, CreatePotState> {
   Future<void> _onCreate(_Create event, Emitter<CreatePotState> emit) async {
     emit(state.copyWith(isLoading: true, error: null));
     try {
-      final potResponse = await _repository.createPot(
+      final potId = await _repository.createPot(
         routeId: event.routeId,
         startsAt: event.startsAt,
         endsAt: event.endsAt,
         maxCount: event.maxCount,
       );
-
-      final potId = json.decode(potResponse)['id'];
 
       emit(state.copyWith(isLoading: false, createdPotId: potId));
     } catch (e) {

--- a/lib/app/modules/create/presentation/pages/create_page.dart
+++ b/lib/app/modules/create/presentation/pages/create_page.dart
@@ -45,10 +45,9 @@ class CreatePage extends StatelessWidget with LogPageStateless {
               context.showToast(state.error!);
               return;
             }
-            if (state.createdPotId != null) return;
+            if (state.createdPotId == null) return;
             context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
-            ChatRoute().push(context);
-            ChatRoomRoute(id: state.createdPotId!).push(context);
+            context.router.popAndPush(ChatRoomRoute(id: state.createdPotId!));
           },
           child: const CreateForm(),
         ),

--- a/lib/app/modules/create/presentation/pages/create_page.dart
+++ b/lib/app/modules/create/presentation/pages/create_page.dart
@@ -1,13 +1,15 @@
-import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/di/locator.dart';
+import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_page.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
 import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_cubit.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_pot_bloc.dart';
 import 'package:pot_g/app/modules/create/presentation/widgets/create_form.dart';
+import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
 @RoutePage()
@@ -36,7 +38,18 @@ class CreatePage extends StatelessWidget with LogPageStateless {
           ),
           BlocProvider<CreatePotBloc>(create: (context) => sl<CreatePotBloc>()),
         ],
-        child: const CreateForm(),
+        child: BlocListener<CreatePotBloc, CreatePotState>(
+          listener: (context, state) {
+            if (state.error != null) {
+              context.showToast(state.error!);
+              return;
+            }
+            if (state.createdPotId != null) return;
+            ListRoute().push(context);
+            ChatRoomRoute(id: state.createdPotId!).push(context);
+          },
+          child: const CreateForm(),
+        ),
       ),
     );
   }

--- a/lib/app/modules/create/presentation/pages/create_page.dart
+++ b/lib/app/modules/create/presentation/pages/create_page.dart
@@ -10,7 +10,6 @@ import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_cubit.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_pot_bloc.dart';
 import 'package:pot_g/app/modules/create/presentation/widgets/create_form.dart';
-import 'package:pot_g/app/modules/list/presentation/bloc/pot_list_bloc.dart';
 import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
@@ -47,9 +46,8 @@ class CreatePage extends StatelessWidget with LogPageStateless {
               return;
             }
             if (state.createdPotId != null) return;
-            context.read<PotListBloc>().add(PotListEvent.search());
             context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
-            ListRoute().push(context);
+            ChatRoute().push(context);
             ChatRoomRoute(id: state.createdPotId!).push(context);
           },
           child: const CreateForm(),

--- a/lib/app/modules/create/presentation/pages/create_page.dart
+++ b/lib/app/modules/create/presentation/pages/create_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/di/locator.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_page.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
@@ -9,6 +10,7 @@ import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_cubit.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_pot_bloc.dart';
 import 'package:pot_g/app/modules/create/presentation/widgets/create_form.dart';
+import 'package:pot_g/app/modules/list/presentation/bloc/pot_list_bloc.dart';
 import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
@@ -45,6 +47,8 @@ class CreatePage extends StatelessWidget with LogPageStateless {
               return;
             }
             if (state.createdPotId != null) return;
+            context.read<PotListBloc>().add(PotListEvent.search());
+            context.read<PotDetailBloc>().add(PotDetailEvent.loadMyPots());
             ListRoute().push(context);
             ChatRoomRoute(id: state.createdPotId!).push(context);
           },

--- a/lib/app/modules/create/presentation/widgets/create_form.dart
+++ b/lib/app/modules/create/presentation/widgets/create_form.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
@@ -11,7 +10,6 @@ import 'package:pot_g/app/modules/core/presentation/bloc/route_list_bloc.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_cubit.dart';
 import 'package:pot_g/app/modules/create/presentation/bloc/create_pot_bloc.dart';
 import 'package:pot_g/app/modules/create/presentation/widgets/time_interval_selector.dart';
-import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/app/values/text_styles.dart';
 import 'package:pot_g/gen/strings.g.dart';
@@ -44,29 +42,27 @@ class CreateForm extends StatelessWidget {
             padding: const EdgeInsets.all(10),
             child: PotButton(
               onPressed: context.select(
-                (CreateCubit cubit) =>
-                    cubit.state.valid
-                        ? () {
-                          L.c('createPot');
-                          final state = cubit.state;
-                          context.read<CreatePotBloc>().add(
-                            CreatePotEvent.create(
-                              routeId: state.route!.id,
-                              startsAt: state.date!.copyWith(
-                                hour: state.startTime!.hour,
-                                minute: state.startTime!.minute,
-                              ),
-                              endsAt: state.date!.copyWith(
-                                hour: state.endTime!.hour,
-                                minute: state.endTime!.minute,
-                              ),
-                              maxCount: state.maxCapacity!,
+                (CreateCubit cubit) => cubit.state.valid
+                    ? () {
+                        L.c('createPot');
+                        final state = cubit.state;
+                        final bloc = context.read<CreatePotBloc>();
+                        bloc.add(
+                          CreatePotEvent.create(
+                            routeId: state.route!.id,
+                            startsAt: state.date!.copyWith(
+                              hour: state.startTime!.hour,
+                              minute: state.startTime!.minute,
                             ),
-                          );
-
-                          context.router.push(ListRoute());
-                        }
-                        : null,
+                            endsAt: state.date!.copyWith(
+                              hour: state.endTime!.hour,
+                              minute: state.endTime!.minute,
+                            ),
+                            maxCount: state.maxCapacity!,
+                          ),
+                        );
+                      }
+                    : null,
               ),
               variant: PotButtonVariant.emphasized,
               child: Text(context.t.create.action),
@@ -196,12 +192,11 @@ class _Capacity extends StatelessWidget {
                   child: Text(
                     context.t.create.capacity.fields.max_capacity.item(n: i),
                     style: TextStyle(
-                      color:
-                          selected == i
-                              ? Palette.primary
-                              : preFilled
-                              ? Palette.textGrey
-                              : Palette.grey,
+                      color: selected == i
+                          ? Palette.primary
+                          : preFilled
+                          ? Palette.textGrey
+                          : Palette.grey,
                     ),
                   ),
                 ),

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -79,7 +79,6 @@ class PotListItem extends StatelessWidget {
     if (result != OkCancelResult.ok) return;
     if (!context.mounted) return;
 
-    // JoinPotBloc을 사용하여 입장 처리
     await _joinPot(context);
   }
 
@@ -101,10 +100,10 @@ class PotListItem extends StatelessWidget {
                 potListBloc.add(PotListEvent.search());
                 potDetailBloc.add(const PotDetailEvent.loadMyPots());
                 Navigator.of(context).pop();
-                _navigateToChatRoom(context, successState.potId);
+                ChatRoomRoute(id: successState.potId).push(context);
               },
               error: (errorState) {
-                Navigator.of(context).pop(); // 로딩 다이얼로그 닫기
+                Navigator.of(context).pop();
                 context.showToast(errorState.message);
               },
             );
@@ -123,11 +122,6 @@ class PotListItem extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  void _navigateToChatRoom(BuildContext context, String potId) {
-    // 채팅방으로 이동
-    ChatRoomRoute(id: pot.id).push(context);
   }
 
   @override

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -5,15 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:pot_g/app/di/locator.dart';
-import 'package:pot_g/app/modules/chat/domain/enums/pot_status.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/date_time.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/general_dialog.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_pressable.dart';
-import 'package:pot_g/app/modules/core/data/models/pot_detail_model.dart';
-import 'package:pot_g/app/modules/core/data/models/route_model.dart';
-import 'package:pot_g/app/modules/core/data/models/stop_model.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_summary_entity.dart';
 import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/modules/list/presentation/bloc/join_pot_bloc.dart';
@@ -33,8 +29,9 @@ class PotListItem extends StatelessWidget {
     Widget field(String label, String value, {bool column = false}) {
       return Flex(
         direction: column ? Axis.vertical : Axis.horizontal,
-        crossAxisAlignment:
-            column ? CrossAxisAlignment.start : CrossAxisAlignment.center,
+        crossAxisAlignment: column
+            ? CrossAxisAlignment.start
+            : CrossAxisAlignment.center,
         children: [
           Text(label, style: TextStyles.title4.copyWith(color: Palette.dark)),
           const SizedBox(width: 8, height: 8),
@@ -47,9 +44,8 @@ class PotListItem extends StatelessWidget {
       context: context,
       title: context.t.list.enter.title,
       child: BlocProvider(
-        create:
-            (context) =>
-                sl<PotOverviewBloc>()..add(PotOverviewEvent.init(pot.id)),
+        create: (context) =>
+            sl<PotOverviewBloc>()..add(PotOverviewEvent.init(pot.id)),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -94,62 +90,44 @@ class PotListItem extends StatelessWidget {
     return showDialog(
       context: context,
       barrierDismissible: false,
-      builder:
-          (context) => BlocProvider(
-            create:
-                (context) => sl<JoinPotBloc>()..add(JoinPotEvent.join(pot.id)),
-            child: BlocListener<JoinPotBloc, JoinPotState>(
-              listener: (context, state) {
-                state.map(
-                  initial: (_) {},
-                  loading: (_) {},
-                  success: (successState) {
-                    potListBloc.add(PotListEvent.search());
-                    potDetailBloc.add(const PotDetailEvent.loadMyPots());
-                    Navigator.of(context).pop();
-                    _navigateToChatRoom(context, successState.potId);
-                  },
-                  error: (errorState) {
-                    Navigator.of(context).pop(); // 로딩 다이얼로그 닫기
-                    context.showToast(errorState.message);
-                  },
-                );
+      builder: (context) => BlocProvider(
+        create: (context) => sl<JoinPotBloc>()..add(JoinPotEvent.join(pot.id)),
+        child: BlocListener<JoinPotBloc, JoinPotState>(
+          listener: (context, state) {
+            state.map(
+              initial: (_) {},
+              loading: (_) {},
+              success: (successState) {
+                potListBloc.add(PotListEvent.search());
+                potDetailBloc.add(const PotDetailEvent.loadMyPots());
+                Navigator.of(context).pop();
+                _navigateToChatRoom(context, successState.potId);
               },
-              child: BlocBuilder<JoinPotBloc, JoinPotState>(
-                builder: (context, state) {
-                  return state.map(
-                    initial: (_) => const SizedBox.shrink(),
-                    loading:
-                        (_) => const Center(child: CircularProgressIndicator()),
-                    success: (_) => const SizedBox.shrink(),
-                    error: (_) => const SizedBox.shrink(),
-                  );
-                },
-              ),
-            ),
+              error: (errorState) {
+                Navigator.of(context).pop(); // 로딩 다이얼로그 닫기
+                context.showToast(errorState.message);
+              },
+            );
+          },
+          child: BlocBuilder<JoinPotBloc, JoinPotState>(
+            builder: (context, state) {
+              return state.map(
+                initial: (_) => const SizedBox.shrink(),
+                loading: (_) =>
+                    const Center(child: CircularProgressIndicator()),
+                success: (_) => const SizedBox.shrink(),
+                error: (_) => const SizedBox.shrink(),
+              );
+            },
           ),
+        ),
+      ),
     );
   }
 
   void _navigateToChatRoom(BuildContext context, String potId) {
-    // PotSummaryEntity를 PotDetailModel로 변환
-    final potDetail = PotDetailModel(
-      id: pot.id,
-      name: pot.name,
-      route: RouteModel(
-        id: pot.route.id,
-        from: StopModel(id: pot.route.from.id, name: pot.route.from.name),
-        to: StopModel(id: pot.route.to.id, name: pot.route.to.name),
-      ),
-      startsAt: pot.startsAt,
-      endsAt: pot.endsAt,
-      current: pot.current,
-      total: pot.total,
-      status: PotStatus.beforeConfirmed, // 기본값으로 beforeConfirmed 설정
-    );
-
     // 채팅방으로 이동
-    ChatRoomRoute(pot: potDetail).push(context);
+    ChatRoomRoute(id: pot.id).push(context);
   }
 
   @override
@@ -240,10 +218,9 @@ class PotListItem extends StatelessWidget {
                                     fontWeight: FontWeight.w500,
                                     height: 0.66,
                                     letterSpacing: -0.025 * 12,
-                                    color:
-                                        disabled
-                                            ? Palette.grey
-                                            : Palette.textGrey,
+                                    color: disabled
+                                        ? Palette.grey
+                                        : Palette.textGrey,
                                   ),
                                 ),
                             ],
@@ -273,11 +250,10 @@ class _DashedLinePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     double dashWidth = 8, dashSpace = 8, startY = 0;
-    final paint =
-        Paint()
-          ..color = Colors.grey
-          ..strokeWidth = 1
-          ..strokeCap = StrokeCap.round;
+    final paint = Paint()
+      ..color = Colors.grey
+      ..strokeWidth = 1
+      ..strokeCap = StrokeCap.round;
     canvas.clipRect(Offset.zero & size);
     canvas.save();
     while (startY < size.height) {

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -5,11 +5,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:pot_g/app/di/locator.dart';
 import 'package:pot_g/app/modules/auth/presentation/bloc/auth_bloc.dart';
-import 'package:pot_g/app/modules/core/presentation/bloc/link_bloc.dart';
-import 'package:pot_g/app/modules/core/presentation/bloc/messaging_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_observer.dart';
+import 'package:pot_g/app/modules/core/presentation/bloc/link_bloc.dart';
+import 'package:pot_g/app/modules/core/presentation/bloc/messaging_bloc.dart';
 import 'package:pot_g/app/modules/core/presentation/bloc/route_list_bloc.dart';
 import 'package:pot_g/app/modules/socket/presentation/bloc/socket_auth_bloc.dart';
 import 'package:pot_g/app/router.dart';
@@ -36,8 +36,8 @@ class PotApp extends StatelessWidget {
           locale: TranslationProvider.of(context).flutterLocale,
           supportedLocales: AppLocaleUtils.supportedLocales,
           localizationsDelegates: GlobalMaterialLocalizations.delegates,
-          builder:
-              (_, child) => _Providers(child: child ?? const SizedBox.shrink()),
+          builder: (_, child) =>
+              _Providers(child: child ?? const SizedBox.shrink()),
         ),
       ),
     );
@@ -68,9 +68,8 @@ class _Providers extends StatelessWidget {
         ),
         BlocProvider(
           lazy: false,
-          create:
-              (_) =>
-                  sl<PotDetailBloc>()..add(const PotDetailEvent.loadMyPots()),
+          create: (_) =>
+              sl<PotDetailBloc>()..add(const PotDetailEvent.loadMyPots()),
         ),
       ],
       child: MultiBlocListener(
@@ -83,6 +82,9 @@ class _Providers extends StatelessWidget {
                   'email': state.user!.email,
                   'name': state.user!.name,
                 });
+                context.read<PotDetailBloc>().add(
+                  const PotDetailEvent.loadMyPots(),
+                );
               }
               final event = switch (state) {
                 Authenticated() => SocketAuthEvent.connect(),
@@ -95,26 +97,22 @@ class _Providers extends StatelessWidget {
             },
           ),
           BlocListener<AuthBloc, AuthState>(
-            listenWhen:
-                (previous, current) =>
-                    current.mapOrNull(
-                      authenticated: (_) => true,
-                      unauthenticated: (_) => true,
-                    ) ??
-                    false,
-            listener:
-                (context, state) => context.read<MessagingBloc>().add(
-                  const MessagingEvent.refresh(),
-                ),
+            listenWhen: (previous, current) =>
+                current.mapOrNull(
+                  authenticated: (_) => true,
+                  unauthenticated: (_) => true,
+                ) ??
+                false,
+            listener: (context, state) => context.read<MessagingBloc>().add(
+              const MessagingEvent.refresh(),
+            ),
           ),
           BlocListener<LinkBloc, LinkState>(
-            listener:
-                (context, state) => state.mapOrNull(
-                  loaded:
-                      (s) => WidgetsBinding.instance.addPostFrameCallback((_) {
-                        _appRouter.pushPath(s.link);
-                      }),
-                ),
+            listener: (context, state) => state.mapOrNull(
+              loaded: (s) => WidgetsBinding.instance.addPostFrameCallback((_) {
+                _appRouter.pushPath(s.link);
+              }),
+            ),
           ),
         ],
         child: child,

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -66,11 +66,7 @@ class _Providers extends StatelessWidget {
           lazy: false,
           create: (_) => sl<LinkBloc>()..add(const LinkEvent.init()),
         ),
-        BlocProvider(
-          lazy: false,
-          create: (_) =>
-              sl<PotDetailBloc>()..add(const PotDetailEvent.loadMyPots()),
-        ),
+        BlocProvider(lazy: false, create: (_) => sl<PotDetailBloc>()),
       ],
       child: MultiBlocListener(
         listeners: [


### PR DESCRIPTION
- **feat: load pot when user authenticated**
- **feat: navigate chat room with pot id**
- **refactor: introduce CreatePotResultModel**
- **feat: navigate to chat room page after create pot**
- **feat: load pots after create pot**
- **fix: go to chat route**
- **fix: condition**
- **feat: refresh and navigate when leave pot**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 채팅방 나가기 흐름 개선: 작업 완료 대기, 오류 시 토스트 표시, 성공 시 목록 새로고침 및 화면 복귀.
  - 팟 생성 후 처리 개선: 생성 결과 모델 사용으로 생성 성공 시 내 팟 새로고침 및 생성된 채팅방으로 이동.

- 리팩터링
  - 채팅방 진입과 네비게이션을 팟 객체 대신 ID 기반으로 통일.
  - 생성 관련 흐름에서 응답 처리 단순화(중간 JSON 디코딩 제거).

- 스타일
  - 위젯 구성 및 코드 포맷 정리(동작 변화 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->