### PR TITLE
fix: ensure departure time is between startsAt and endsAt

### DIFF
--- a/lib/app/modules/chat/data/models/confirm_departure_time_response_model.dart
+++ b/lib/app/modules/chat/data/models/confirm_departure_time_response_model.dart
@@ -24,4 +24,5 @@ enum PotDepartureTimeResult {
   beforeNow,
   potNotExist,
   potAlreadyClosed,
+  notInAvailableTimeRange,
 }

--- a/lib/app/modules/chat/data/repositories/websocket_pot_action_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_action_repository.dart
@@ -38,6 +38,8 @@ class WebsocketPotActionRepository implements PotActionRepository {
           throw DepartureTimeException.potNotExist();
         case PotDepartureTimeResult.potAlreadyClosed:
           throw DepartureTimeException.potAlreadyClosed();
+        case PotDepartureTimeResult.notInAvailableTimeRange:
+          throw DepartureTimeException.notInAvailableTimeRange();
       }
     } on DioException catch (e) {
       throw DepartureTimeException.networkError(

--- a/lib/app/modules/chat/domain/exceptions/departure_time_exception.dart
+++ b/lib/app/modules/chat/domain/exceptions/departure_time_exception.dart
@@ -6,6 +6,8 @@ sealed class DepartureTimeException implements Exception {
   factory DepartureTimeException.beforeNow() = BeforeNowException;
   factory DepartureTimeException.potNotExist() = PotNotExistException;
   factory DepartureTimeException.potAlreadyClosed() = PotAlreadyClosedException;
+  factory DepartureTimeException.notInAvailableTimeRange() =
+      NotInAvailableTimeRangeException;
   factory DepartureTimeException.networkError(String error) =
       NetworkErrorException;
 }
@@ -28,6 +30,10 @@ class PotNotExistException extends DepartureTimeException {
 
 class PotAlreadyClosedException extends DepartureTimeException {
   const PotAlreadyClosedException();
+}
+
+class NotInAvailableTimeRangeException extends DepartureTimeException {
+  const NotInAvailableTimeRangeException();
 }
 
 class NetworkErrorException extends DepartureTimeException {

--- a/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
@@ -31,7 +31,9 @@ class PotActionBloc extends Bloc<PotActionEvent, PotActionState> {
       );
       await _repository.setDepartureTime(
         event.pot,
-        adjustedDate.isBefore(s) ? adjustedDate.add(Duration(days: 1)) : s,
+        adjustedDate.isBefore(s)
+            ? adjustedDate.add(Duration(days: 1))
+            : adjustedDate,
       );
       emit(const PotActionState.success());
     } catch (e) {

--- a/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_action_bloc.dart
@@ -23,7 +23,16 @@ class PotActionBloc extends Bloc<PotActionEvent, PotActionState> {
   ) async {
     emit(const PotActionState.loading());
     try {
-      await _repository.setDepartureTime(event.pot, event.date);
+      final s = event.pot.startsAt;
+      final adjustedDate = event.date.copyWith(
+        year: s.year,
+        month: s.month,
+        day: s.day,
+      );
+      await _repository.setDepartureTime(
+        event.pot,
+        adjustedDate.isBefore(s) ? adjustedDate.add(Duration(days: 1)) : s,
+      );
       emit(const PotActionState.success());
     } catch (e) {
       emit(PotActionState.error(e.toString()));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pot_g
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.0
+version: 1.0.0
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * 팟 시작 날짜 이전으로 출발 시간을 설정할 수 없도록 조정되었습니다. 이 경우 출발 날짜가 자동으로 다음 날로 보정됩니다.
* **변경사항**
  * 출발 시간 확인 결과에 "사용 불가 시간대" 상태가 추가되어, 허용되지 않는 시간을 선택하면 명확한 오류 응답이 제공됩니다.
* **기타**
  * 패키지 버전이 1.0.0으로 상향되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->