### PR TITLE
feat: show channel banner

### DIFF
--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -180,10 +180,11 @@ class _Listeners extends StatelessWidget {
       child: UpdateListener(
         child: BlocBuilder<ApiChannelBloc, ApiChannelState>(
           builder: (context, state) {
-            if (state.channel == ApiChannel.prod) return child;
+            final channel = state.channel;
+            if (channel == null || channel == ApiChannel.prod) return child;
             return Banner(
               color: Colors.orange,
-              message: state.channel?.name ?? '',
+              message: channel.name,
               location: BannerLocation.topStart,
               child: child,
             );

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -11,6 +11,7 @@ import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_observer.dart';
+import 'package:pot_g/app/modules/core/domain/enums/api_channel.dart';
 import 'package:pot_g/app/modules/core/presentation/bloc/api_channel_bloc.dart';
 import 'package:pot_g/app/modules/core/presentation/bloc/app_version_bloc.dart';
 import 'package:pot_g/app/modules/core/presentation/bloc/link_bloc.dart';
@@ -176,7 +177,19 @@ class _Listeners extends StatelessWidget {
           },
         ),
       ],
-      child: UpdateListener(child: child),
+      child: UpdateListener(
+        child: BlocBuilder<ApiChannelBloc, ApiChannelState>(
+          builder: (context, state) {
+            if (state.channel == ApiChannel.prod) return child;
+            return Banner(
+              color: Colors.orange,
+              message: state.channel?.name ?? '',
+              location: BannerLocation.topStart,
+              child: child,
+            );
+          },
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 개발/스테이징 등 비-프로덕션 API 채널을 앱 상단에 오렌지색 배너로 표시합니다(좌상단에 채널명 표시). 프로덕션인 경우 기존 화면과 동일하게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->