### PR TITLE
feat: refresh chat list after pot action

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -2,7 +2,8 @@
   "name": "PotG",
   "common": {
     "confirm": "Confirm",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "refresh": "Refresh"
   },
   "unauthorized": {
     "title": "Login to continue",

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -2,7 +2,8 @@
   "name": "팟쥐",
   "common": {
     "confirm": "확인",
-    "cancel": "취소"
+    "cancel": "취소",
+    "refresh": "새로고침"
   },
   "unauthorized": {
     "title": "로그인 하러 가시겠습니까?",

--- a/lib/app/modules/chat/data/repositories/rest_pot_detail_repository.dart
+++ b/lib/app/modules/chat/data/repositories/rest_pot_detail_repository.dart
@@ -10,8 +10,8 @@ class RestPotDetailRepository implements PotDetailRepository {
   RestPotDetailRepository(this._api);
 
   @override
-  Future<MyPotsModel> getMyPotList() async {
+  Stream<MyPotsModel> getMyPotList() async* {
     final MyPotsModel pots = await _api.getMyPots();
-    return pots;
+    yield pots;
   }
 }

--- a/lib/app/modules/chat/data/repositories/rest_pot_detail_repository.dart
+++ b/lib/app/modules/chat/data/repositories/rest_pot_detail_repository.dart
@@ -2,16 +2,37 @@ import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_pot_api.dart';
 import 'package:pot_g/app/modules/chat/data/models/my_pots_model.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_detail_repository.dart';
+import 'package:pot_g/app/modules/socket/data/data_sources/websocket.dart';
+import 'package:pot_g/app/modules/socket/data/models/events/pot_event_model.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/accounting_confirm_v1_event.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/accounting_request_v1_event.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/archive_v1_event.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/create_v1_event.dart';
+import 'package:pot_g/app/modules/socket/data/models/pot_events/departure_confirm_v1_event.dart';
+
+bool _isPotStatusChangeEvent(PotEventModel e) {
+  return e is PotEventModel<CreateV1Event> ||
+      e is PotEventModel<ArchiveV1Event> ||
+      e is PotEventModel<DepartureConfirmV1Event> ||
+      e is PotEventModel<AccountingRequestV1Event> ||
+      e is PotEventModel<AccountingConfirmV1Event>;
+}
 
 @Injectable(as: PotDetailRepository)
 class RestPotDetailRepository implements PotDetailRepository {
   final ChatPotApi _api;
+  final PotGSocket _socket;
 
-  RestPotDetailRepository(this._api);
+  RestPotDetailRepository(this._api, this._socket);
 
   @override
   Stream<MyPotsModel> getMyPotList() async* {
     final MyPotsModel pots = await _api.getMyPots();
     yield pots;
+    yield* _socket
+        .createStreamFor<PotEventModel>()
+        .map((e) => e.body)
+        .where(_isPotStatusChangeEvent)
+        .asyncMap((_) => _api.getMyPots());
   }
 }

--- a/lib/app/modules/chat/domain/entities/pot_info_entity.dart
+++ b/lib/app/modules/chat/domain/entities/pot_info_entity.dart
@@ -7,3 +7,7 @@ abstract class PotInfoEntity implements PotOverviewEntity {
   PotStatus get status;
   PotAccountingInfoEntity get accountingInfo;
 }
+
+extension PotInfoEntityX on PotInfoEntity {
+  bool get isArchived => status == PotStatus.archived;
+}

--- a/lib/app/modules/chat/domain/repositories/pot_detail_repository.dart
+++ b/lib/app/modules/chat/domain/repositories/pot_detail_repository.dart
@@ -1,5 +1,5 @@
 import 'package:pot_g/app/modules/chat/data/models/my_pots_model.dart';
 
 abstract class PotDetailRepository {
-  Future<MyPotsModel> getMyPotList();
+  Stream<MyPotsModel> getMyPotList();
 }

--- a/lib/app/modules/chat/presentation/bloc/pot_detail_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_detail_bloc.dart
@@ -30,8 +30,8 @@ class PotDetailBloc extends Bloc<PotDetailEvent, PotDetailState> {
         ),
       );
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(state.copyWith(isLoading: false, error: e.toString()));
+      final errorId = L.e(e, stackTrace);
+      emit(state.copyWith(isLoading: false, error: '$e ($errorId)'));
     }
   }
 }

--- a/lib/app/modules/chat/presentation/bloc/pot_detail_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_detail_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
@@ -11,28 +12,23 @@ part 'pot_detail_bloc.freezed.dart';
 class PotDetailBloc extends Bloc<PotDetailEvent, PotDetailState> {
   final PotDetailRepository _repository;
 
-  PotDetailBloc(this._repository) : super(const PotDetailState()) {
-    on<_LoadMyPots>(_onLoadMyPots);
+  PotDetailBloc(this._repository) : super(const PotDetailState.initial()) {
+    on<_LoadMyPots>(_onLoadMyPots, transformer: restartable());
   }
 
   Future<void> _onLoadMyPots(
     _LoadMyPots event,
     Emitter<PotDetailState> emit,
   ) async {
-    emit(state.copyWith(isLoading: true, error: null));
-    try {
-      final pots = await _repository.getMyPotList();
-      emit(
-        state.copyWith(
-          isLoading: false,
-          activePotList: pots.potList,
-          archivedPotList: pots.archivedPotList,
-        ),
-      );
-    } catch (e, stackTrace) {
-      final errorId = L.e(e, stackTrace);
-      emit(state.copyWith(isLoading: false, error: '$e ($errorId)'));
-    }
+    emit(const _Loading());
+    return emit.forEach(
+      _repository.getMyPotList(),
+      onData: (pots) => _Loaded(pots.potList, pots.archivedPotList),
+      onError: (error, stackTrace) {
+        final errorId = L.e(error, stackTrace);
+        return _Error(error, errorId);
+      },
+    );
   }
 }
 
@@ -43,10 +39,27 @@ sealed class PotDetailEvent with _$PotDetailEvent {
 
 @freezed
 sealed class PotDetailState with _$PotDetailState {
-  const factory PotDetailState({
-    @Default(false) bool isLoading,
-    String? error,
-    @Default([]) List<PotDetailModel> activePotList,
-    @Default([]) List<PotDetailModel> archivedPotList,
-  }) = _State;
+  const PotDetailState._();
+
+  const factory PotDetailState.initial() = _Initial;
+  const factory PotDetailState.loading() = _Loading;
+  const factory PotDetailState.error(Object error, String errorId) = _Error;
+  const factory PotDetailState.loaded(
+    List<PotDetailModel> activePotList,
+    List<PotDetailModel> archivedPotList,
+  ) = _Loaded;
+
+  List<PotDetailModel> get activePotList => switch (this) {
+    _Loaded(:final activePotList) => activePotList,
+    _ => [],
+  };
+  List<PotDetailModel> get archivedPotList => switch (this) {
+    _Loaded(:final archivedPotList) => archivedPotList,
+    _ => [],
+  };
+
+  bool get isLoading => switch (this) {
+    _Loading() => true,
+    _ => false,
+  };
 }

--- a/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
-import 'package:pot_g/app/modules/chat/domain/enums/pot_status.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_info_repository.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
@@ -49,9 +48,5 @@ sealed class PotInfoState with _$PotInfoState {
   String? get error => switch (this) {
     _Error(:final message) => message,
     _ => null,
-  };
-  bool get isArchived => switch (this) {
-    _Loaded(:final pot) => pot.status == PotStatus.archived,
-    _ => false,
   };
 }

--- a/lib/app/modules/chat/presentation/pages/chat_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_page.dart
@@ -25,17 +25,13 @@ class ChatPage extends StatelessWidget {
       ),
       body: BlocBuilder<PotDetailBloc, PotDetailState>(
         builder: (context, state) {
-          if (state.isLoading) {
-            return const Center(child: CircularProgressIndicator());
-          }
-
-          if (state.error != null) {
-            return Center(child: Text('Error: ${state.error}'));
-          }
-
-          return _ChatListView(
-            activePots: state.activePotList,
-            closedPots: state.archivedPotList,
+          return state.maybeMap(
+            error: (e) => Center(child: Text('Error: ${e.error}')),
+            loaded: (s) => _ChatListView(
+              activePots: s.activePotList,
+              closedPots: s.archivedPotList,
+            ),
+            orElse: () => const Center(child: CircularProgressIndicator()),
           );
         },
       ),

--- a/lib/app/modules/chat/presentation/pages/chat_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_list_item.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/error_cover.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
 import 'package:pot_g/app/modules/core/data/models/pot_detail_model.dart';
 import 'package:pot_g/app/values/palette.dart';
@@ -26,7 +27,14 @@ class ChatPage extends StatelessWidget {
       body: BlocBuilder<PotDetailBloc, PotDetailState>(
         builder: (context, state) {
           return state.maybeMap(
-            error: (e) => Center(child: Text('Error: ${e.error}')),
+            error: (e) => ErrorCover(
+              message: '${e.error} (${e.errorId})',
+              onRefresh: () {
+                context.read<PotDetailBloc>().add(
+                  const PotDetailEvent.loadMyPots(),
+                );
+              },
+            ),
             loaded: (s) => _ChatListView(
               activePots: s.activePotList,
               closedPots: s.archivedPotList,

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -5,6 +5,7 @@ import 'package:pot_g/app/di/locator.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
+import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/extensions/pot_action_exception.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/accounting_button.dart';
@@ -66,6 +67,9 @@ class ChatRoomPage extends StatelessWidget with LogPage {
           BlocListener<PotActionBloc, PotActionState>(
             listener: (context, state) {
               state.mapOrNull(
+                success: (_) => context.read<PotDetailBloc>().add(
+                  const PotDetailEvent.loadMyPots(),
+                ),
                 departureTimeError: (e) => context.showToast(
                   '${e.err.getErrorMessage(context)} (${e.errorId})',
                 ),

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pot_g/app/di/locator.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_accounting_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_action_bloc.dart';
@@ -96,9 +97,19 @@ class ChatRoomPage extends StatelessWidget with LogPage {
         child: BlocBuilder<PotInfoBloc, PotInfoState>(
           builder: (context, state) {
             if (state.error != null) {
-              return ErrorCover(message: state.error!);
+              return ErrorCover(
+                message: state.error!,
+                onRefresh: () {
+                  context.read<PotInfoBloc>().add(
+                    PotInfoEvent.init(_PotId(id: id)),
+                  );
+                },
+              );
             }
-            return _Layout();
+            if (state.pot == null) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return _Layout(pot: state.pot!);
           },
         ),
       ),
@@ -107,15 +118,13 @@ class ChatRoomPage extends StatelessWidget with LogPage {
 }
 
 class _Layout extends StatelessWidget {
-  const _Layout();
+  const _Layout({required this.pot});
+
+  final PotInfoEntity pot;
 
   @override
   Widget build(BuildContext context) {
-    final state = context.watch<PotInfoBloc>().state;
-    if (state.error != null) return ErrorCover(message: state.error!);
-    if (state.pot == null) return Scaffold();
-    final pot = state.pot!;
-    final disabled = state.isArchived;
+    final disabled = pot.isArchived;
     return Scaffold(
       backgroundColor: disabled ? const Color(0xfff0f0f0) : null,
       appBar: PotAppBar(title: Text(pot.name)),

--- a/lib/app/modules/chat/presentation/widgets/chat_input.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_input.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/chat_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
@@ -36,7 +37,7 @@ class _ChatInputState extends State<ChatInput> {
   @override
   Widget build(BuildContext context) {
     final disabled = context.select<PotInfoBloc, bool>(
-      (bloc) => bloc.state.isArchived,
+      (bloc) => bloc.state.pot?.isArchived ?? false,
     );
     return Container(
       padding: EdgeInsets.symmetric(vertical: 8),

--- a/lib/app/modules/common/presentation/widgets/error_cover.dart
+++ b/lib/app/modules/common/presentation/widgets/error_cover.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
 import 'package:pot_g/app/values/palette.dart';
+import 'package:pot_g/gen/strings.g.dart';
 
 class ErrorCover extends StatelessWidget {
-  const ErrorCover({super.key, required this.message});
+  const ErrorCover({super.key, required this.message, this.onRefresh});
 
   final String message;
+  final VoidCallback? onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -38,6 +40,18 @@ class ErrorCover extends StatelessWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
+              if (onRefresh != null) ...[
+                const SizedBox(height: 24),
+                OutlinedButton.icon(
+                  onPressed: onRefresh,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(context.t.common.refresh),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Palette.warning,
+                    side: BorderSide(color: Palette.warning.withAlpha(100)),
+                  ),
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -176,6 +176,18 @@ class _Listeners extends StatelessWidget {
             _router.replaceAll([ListRoute()]);
           },
         ),
+        BlocListener<PotDetailBloc, PotDetailState>(
+          listener: (context, state) {
+            state.mapOrNull(
+              error: (e) {
+                context.showToast('${e.error} (${e.errorId})');
+                context.read<PotDetailBloc>().add(
+                  const PotDetailEvent.loadMyPots(),
+                );
+              },
+            );
+          },
+        ),
       ],
       child: UpdateListener(
         child: BlocBuilder<ApiChannelBloc, ApiChannelState>(

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -179,12 +179,7 @@ class _Listeners extends StatelessWidget {
         BlocListener<PotDetailBloc, PotDetailState>(
           listener: (context, state) {
             state.mapOrNull(
-              error: (e) {
-                context.showToast('${e.error} (${e.errorId})');
-                context.read<PotDetailBloc>().add(
-                  const PotDetailEvent.loadMyPots(),
-                );
-              },
+              error: (e) => context.showToast('${e.error} (${e.errorId})'),
             );
           },
         ),


### PR DESCRIPTION
- **chore: refresh chat list after pot action**
- **feat: potDetailBloc error id**
- **feat: make pot list stream**
- **feat: listen pot status change socket event**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팟 상태 변경 시 소켓 기반 실시간 스트리밍으로 팟 목록 자동 갱신 제공
  * 오류 화면에 "새로고침" 버튼(콜백) 추가

* **개선 사항**
  * 로딩/오류/완료를 명확히 구분하는 상태 모델로 재구성하여 UI 흐름 개선
  * 팟 아카이브 여부 접근성 개선(isArchived 확장 getter) 및 입력/화면에서 해당 상태 반영
  * 오류 발생 시 토스트 알림 표시 및 재시도 흐름 보강

* **문서/지역화**
  * "새로고침" 다국어 문자열 추가 (영/한)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->