### PR TITLE
fix: disable send button when field empty

### DIFF
--- a/lib/app/modules/chat/presentation/widgets/chat_input.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_input.dart
@@ -24,7 +24,7 @@ class _ChatInputState extends State<ChatInput> {
   void initState() {
     super.initState();
     _controller.addListener(() {
-      setState(() => _filled = _controller.text.isNotEmpty);
+      setState(() => _filled = _controller.text.trim().isNotEmpty);
     });
   }
 
@@ -76,11 +76,15 @@ class _ChatInputState extends State<ChatInput> {
                 BlendMode.srcIn,
               ),
             ),
-            onPressed: () {
-              L.c('sendMessage');
-              context.read<ChatBloc>().add(ChatSendChat(_controller.text));
-              _controller.clear();
-            },
+            onPressed: _filled
+                ? () {
+                    L.c('sendMessage');
+                    context.read<ChatBloc>().add(
+                      ChatSendChat(_controller.text.trim()),
+                    );
+                    _controller.clear();
+                  }
+                : null,
           ),
         ],
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 채팅 입력창이 공백만 입력된 경우를 빈 입력으로 올바르게 인식하여 전송 버튼의 활성화 상태를 적절히 관리합니다.
* 메시지 전송 시 입력 필드의 앞뒤 공백이 자동으로 제거되어 정리된 형태로 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->