### PR TITLE
fix: accounting number text field max length

### DIFF
--- a/lib/app/modules/common/presentation/widgets/pot_text_field.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_text_field.dart
@@ -15,6 +15,7 @@ class PotTextField extends StatelessWidget {
     this.inputFormatters,
     this.onChanged,
     this.autoFocus = false,
+    this.maxLength,
   });
   final Widget? suffixIcon;
   final String? hintText;
@@ -25,10 +26,12 @@ class PotTextField extends StatelessWidget {
   final List<TextInputFormatter>? inputFormatters;
   final void Function(String)? onChanged;
   final bool autoFocus;
+  final int? maxLength;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      maxLength: maxLength,
       autofocus: autoFocus,
       readOnly: readOnly,
       style: TextStyles.body.copyWith(color: Palette.dark),

--- a/lib/app/modules/common/presentation/widgets/pot_text_field.dart
+++ b/lib/app/modules/common/presentation/widgets/pot_text_field.dart
@@ -16,6 +16,7 @@ class PotTextField extends StatelessWidget {
     this.onChanged,
     this.autoFocus = false,
     this.maxLength,
+    this.automaticCounter = true,
   });
   final Widget? suffixIcon;
   final String? hintText;
@@ -27,6 +28,7 @@ class PotTextField extends StatelessWidget {
   final void Function(String)? onChanged;
   final bool autoFocus;
   final int? maxLength;
+  final bool automaticCounter;
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +41,7 @@ class PotTextField extends StatelessWidget {
       inputFormatters: inputFormatters,
       onChanged: onChanged,
       decoration: InputDecoration(
+        counter: automaticCounter ? null : const SizedBox(),
         suffixIcon: suffixIcon != null
             ? Padding(padding: const EdgeInsets.all(12), child: suffixIcon)
             : null,

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -425,7 +425,8 @@ class _BankNumberState extends State<_BankNumber> {
             Keypad(controller: controller),
             const SizedBox(height: 20),
             PotButton(
-              onPressed: controller.text.length > 5
+              onPressed:
+                  controller.text.length >= 7 && controller.text.length <= 14
                   ? () {
                       L.c('registerBankAccount', from: 'bankAccountNumber');
                       bloc.add(

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -426,7 +426,7 @@ class _BankNumberState extends State<_BankNumber> {
             const SizedBox(height: 20),
             PotButton(
               onPressed:
-                  controller.text.length >= 7 && controller.text.length <= 14
+                  controller.text.length >= 5 && controller.text.length <= 20
                   ? () {
                       L.c('registerBankAccount', from: 'bankAccountNumber');
                       bloc.add(

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -411,6 +411,7 @@ class _BankNumberState extends State<_BankNumber> {
             const SizedBox(height: 20),
             PotTextField(
               maxLength: 20,
+              automaticCounter: false,
               autoFocus: true,
               filled: true,
               controller: controller,

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -410,6 +410,7 @@ class _BankNumberState extends State<_BankNumber> {
             ),
             const SizedBox(height: 20),
             PotTextField(
+              maxLength: 20,
               autoFocus: true,
               filled: true,
               controller: controller,


### PR DESCRIPTION
- **fix: account number limit**
- **fix: change range**
- **feat: text field max length**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 텍스트 입력 필드에 최대 길이 설정과 입력 카운터 표시 on/off 옵션 추가

* **버그 수정**
  * 계좌번호 입력에 최대 길이(20자) 적용
  * 제출 버튼이 입력 길이 5~20자일 때만 활성화되도록 입력 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->