### PR TITLE
feat: handle os notification setting

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -43,6 +43,10 @@
       "room": {
         "title": "Join/Leave Notifications",
         "description": "Receive notifications for changing members"
+      },
+      "os_permission": {
+        "warning": "OS notification settings are disabled. You cannot receive notifications.",
+        "open_settings": "Open OS Settings"
       }
     },
     "account_number_settings": {

--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -3,7 +3,8 @@
   "common": {
     "confirm": "Confirm",
     "cancel": "Cancel",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "unavailable": "Coming soon!"
   },
   "unauthorized": {
     "title": "Login to continue",

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -3,7 +3,8 @@
   "common": {
     "confirm": "확인",
     "cancel": "취소",
-    "refresh": "새로고침"
+    "refresh": "새로고침",
+    "unavailable": "곧 지원할 예정이에요!"
   },
   "unauthorized": {
     "title": "로그인 하러 가시겠습니까?",

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -43,6 +43,10 @@
       "room": {
         "title": "입/퇴장 알림",
         "description": "참여중인 팟의 멤버 변동 알림"
+      },
+      "os_permission": {
+        "warning": "OS 알림 설정이 비활성화되어 있어 알림을 받을 수 없습니다.",
+        "open_settings": "OS 설정으로 이동"
       }
     },
     "account_number_settings": {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,5 +39,12 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_NOTIFICATIONS=1',
+      ]
+    end
   end
 end

--- a/lib/app/modules/chat/presentation/widgets/chat_list.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list.dart
@@ -171,7 +171,7 @@ class _ChatListState extends State<ChatList> {
         //     break;
         // }
         // TODO: implement this action
-        context.showToast('service is not available yet');
+        context.showToast(context.t.common.unavailable);
         break;
       case FofoActionButtonType.accountingProcess:
         final accountingInfo = widget.pot.accountingInfo;

--- a/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
+++ b/lib/app/modules/core/data/repositories/fcm_messaging_repository.dart
@@ -13,7 +13,6 @@ import 'package:pot_g/app/modules/core/domain/repositories/app_version_repositor
 import 'package:pot_g/app/modules/core/domain/repositories/link_repository.dart';
 import 'package:pot_g/app/modules/core/domain/repositories/messaging_repository.dart';
 import 'package:rxdart/rxdart.dart';
-//import 'package:package_info_plus/package_info_plus.dart';
 
 // TODO: https://firebase.google.com/docs/cloud-messaging/flutter/receive?hl=en#apple_platforms_and_android
 

--- a/lib/app/modules/user/data/repositories/rest_push_setting_repository.dart
+++ b/lib/app/modules/user/data/repositories/rest_push_setting_repository.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
-import 'package:permission_handler/permission_handler.dart';
+import 'package:permission_handler/permission_handler.dart'
+    as permission_handler;
 import 'package:pot_g/app/modules/user/data/data_source/remote/user_api.dart';
 import 'package:pot_g/app/modules/user/data/models/push_setting_model.dart';
 import 'package:pot_g/app/modules/user/domain/entities/push_setting_entity.dart';
@@ -28,12 +29,13 @@ class RestPushSettingRepository implements PushSettingRepository {
   }
 
   @override
-  Future<bool> checkOsNotificationPermission() {
-    return Permission.notification.status.then((status) => status.isGranted);
+  Future<bool> checkOsNotificationPermission() async {
+    final status = await permission_handler.Permission.notification.status;
+    return status == permission_handler.PermissionStatus.granted;
   }
 
   @override
   Future<void> openAppSettings() {
-    return openAppSettings();
+    return permission_handler.openAppSettings();
   }
 }

--- a/lib/app/modules/user/data/repositories/rest_push_setting_repository.dart
+++ b/lib/app/modules/user/data/repositories/rest_push_setting_repository.dart
@@ -1,4 +1,5 @@
 import 'package:injectable/injectable.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:pot_g/app/modules/user/data/data_source/remote/user_api.dart';
 import 'package:pot_g/app/modules/user/data/models/push_setting_model.dart';
 import 'package:pot_g/app/modules/user/domain/entities/push_setting_entity.dart';
@@ -24,5 +25,15 @@ class RestPushSettingRepository implements PushSettingRepository {
         marketingPush: pushSetting.marketingPush,
       ),
     );
+  }
+
+  @override
+  Future<bool> checkOsNotificationPermission() {
+    return Permission.notification.status.then((status) => status.isGranted);
+  }
+
+  @override
+  Future<void> openAppSettings() {
+    return openAppSettings();
   }
 }

--- a/lib/app/modules/user/domain/repositories/push_setting_repository.dart
+++ b/lib/app/modules/user/domain/repositories/push_setting_repository.dart
@@ -4,4 +4,6 @@ import 'package:pot_g/app/modules/user/domain/entities/self_user_entity.dart';
 abstract class PushSettingRepository {
   Future<SelfUserEntity> getUser();
   Future<PushSettingEntity> updatePush(PushSettingEntity pushSetting);
+  Future<bool> checkOsNotificationPermission();
+  Future<void> openAppSettings();
 }

--- a/lib/app/modules/user/presentation/blocs/push_setting_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/push_setting_bloc.dart
@@ -15,13 +15,22 @@ class PushSettingBloc extends Bloc<PushSettingEvent, PushSettingState> {
     : super(const PushSettingState.initial()) {
     on<_Load>(_onLoad);
     on<_Update>(_onUpdate);
+    on<_CheckOsPermission>(_onCheckOsPermission);
+    on<_OpenAppSettings>(_onOpenAppSettings);
   }
 
   Future<void> _onLoad(_Load event, Emitter<PushSettingState> emit) async {
     emit(const PushSettingState.loading());
     try {
       final user = await _pushSettingRepository.getUser();
-      emit(PushSettingState.loaded(user.pushSetting));
+      final isOsNotificationEnabled = await _pushSettingRepository
+          .checkOsNotificationPermission();
+      emit(
+        PushSettingState.loaded(
+          user.pushSetting,
+          isOsNotificationEnabled: isOsNotificationEnabled,
+        ),
+      );
     } catch (e, stackTrace) {
       L.e(e, stackTrace);
       emit(PushSettingState.error(e.toString()));
@@ -33,11 +42,52 @@ class PushSettingBloc extends Bloc<PushSettingEvent, PushSettingState> {
       final updated = await _pushSettingRepository.updatePush(
         event.pushSetting,
       );
-      emit(PushSettingState.loaded(updated));
+      final currentState = state;
+      if (currentState is _Loaded) {
+        emit(
+          PushSettingState.loaded(
+            updated,
+            isOsNotificationEnabled: currentState.isOsNotificationEnabled,
+          ),
+        );
+      } else {
+        final isOsNotificationEnabled = await _pushSettingRepository
+            .checkOsNotificationPermission();
+        emit(
+          PushSettingState.loaded(
+            updated,
+            isOsNotificationEnabled: isOsNotificationEnabled,
+          ),
+        );
+      }
     } catch (e, stackTrace) {
       L.e(e, stackTrace);
       emit(PushSettingState.error(e.toString()));
     }
+  }
+
+  Future<void> _onCheckOsPermission(
+    _CheckOsPermission event,
+    Emitter<PushSettingState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is _Loaded) {
+      final isOsNotificationEnabled = await _pushSettingRepository
+          .checkOsNotificationPermission();
+      emit(
+        PushSettingState.loaded(
+          currentState.pushSetting,
+          isOsNotificationEnabled: isOsNotificationEnabled,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onOpenAppSettings(
+    _OpenAppSettings event,
+    Emitter<PushSettingState> emit,
+  ) async {
+    await _pushSettingRepository.openAppSettings();
   }
 }
 
@@ -46,6 +96,8 @@ sealed class PushSettingEvent with _$PushSettingEvent {
   const factory PushSettingEvent.load() = _Load;
   const factory PushSettingEvent.update(PushSettingEntity pushSetting) =
       _Update;
+  const factory PushSettingEvent.checkOsPermission() = _CheckOsPermission;
+  const factory PushSettingEvent.openAppSettings() = _OpenAppSettings;
 }
 
 @freezed
@@ -54,7 +106,9 @@ sealed class PushSettingState with _$PushSettingState {
 
   const factory PushSettingState.initial() = _Initial;
   const factory PushSettingState.loading() = _Loading;
-  const factory PushSettingState.loaded(PushSettingEntity pushSetting) =
-      _Loaded;
+  const factory PushSettingState.loaded(
+    PushSettingEntity pushSetting, {
+    @Default(true) bool isOsNotificationEnabled,
+  }) = _Loaded;
   const factory PushSettingState.error(String message) = _Error;
 }

--- a/lib/app/modules/user/presentation/pages/notification_setting_page.dart
+++ b/lib/app/modules/user/presentation/pages/notification_setting_page.dart
@@ -43,7 +43,6 @@ class _NotificationSettingPageState extends State<_NotificationSettingPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    context.read<PushSettingBloc>().add(const PushSettingEvent.load());
   }
 
   @override

--- a/lib/app/modules/user/presentation/pages/notification_setting_page.dart
+++ b/lib/app/modules/user/presentation/pages/notification_setting_page.dart
@@ -5,6 +5,7 @@ import 'package:pot_g/app/di/locator.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_page.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
+import 'package:pot_g/app/modules/common/presentation/widgets/pot_button.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_toggle.dart';
 import 'package:pot_g/app/modules/user/data/models/push_setting_model.dart';
 import 'package:pot_g/app/modules/user/domain/entities/push_setting_entity.dart';
@@ -28,13 +29,40 @@ class NotificationSettingPage extends StatelessWidget with LogPage {
   }
 }
 
-class _NotificationSettingPage extends StatelessWidget {
+class _NotificationSettingPage extends StatefulWidget {
   const _NotificationSettingPage();
 
   @override
-  Widget build(BuildContext context) {
-    context.read<PushSettingBloc>().add(const PushSettingEvent.load());
+  State<_NotificationSettingPage> createState() =>
+      _NotificationSettingPageState();
+}
 
+class _NotificationSettingPageState extends State<_NotificationSettingPage>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    context.read<PushSettingBloc>().add(const PushSettingEvent.load());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      context.read<PushSettingBloc>().add(
+        const PushSettingEvent.checkOsPermission(),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: PotAppBar(
         title: Text(context.t.profile.notification_settings.title),
@@ -48,9 +76,20 @@ class _NotificationSettingPage extends StatelessWidget {
               loading: (_) => const Center(child: CircularProgressIndicator()),
               loaded: (s) {
                 final pushSetting = s.pushSetting;
+                final isOsNotificationEnabled = s.isOsNotificationEnabled;
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    if (!isOsNotificationEnabled) ...[
+                      _OsNotificationWarningBanner(
+                        onTap: () {
+                          context.read<PushSettingBloc>().add(
+                            const PushSettingEvent.openAppSettings(),
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                    ],
                     _NotificationOption(
                       title: context.t.profile.notification_settings.all.title,
                       description: context
@@ -129,6 +168,64 @@ class _NotificationSettingPage extends StatelessWidget {
 
   void _updatePush(BuildContext context, PushSettingEntity updated) {
     context.read<PushSettingBloc>().add(PushSettingEvent.update(updated));
+  }
+}
+
+class _OsNotificationWarningBanner extends StatelessWidget {
+  const _OsNotificationWarningBanner({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.orange.shade50,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.orange.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.warning_amber_rounded,
+                color: Colors.orange.shade700,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  context.t.profile.notification_settings.os_permission.warning,
+                  style: TextStyles.caption.copyWith(
+                    color: Colors.orange.shade900,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            child: PotButton(
+              onPressed: onTap,
+              variant: PotButtonVariant.outlined,
+              size: PotButtonSize.medium,
+              child: Text(
+                context
+                    .t
+                    .profile
+                    .notification_settings
+                    .os_permission
+                    .open_settings,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
- **chore: unavailable translation**
- **refactor: remove unused import**
- **chore: add i18n**
- **feat: add os setting in push setting bloc, repository**
- **fix(iOS): use notification permission handler**
- **feat: os notification disabled banner**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OS 알림 권한 자동 감지 추가
  * OS 알림이 비활성화된 경우 앱 내 경고 배너 표시
  * 경고 배너에서 직접 OS 설정 열기 가능
  * 앱 활성화(포그라운드 복귀) 시 권한 재확인
  * 미지원 기능에 "곧 지원할 예정" 안내 문구(한국어/영어) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->