### PR TITLE
fix: refetch chats when return from background

### DIFF
--- a/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
@@ -29,7 +29,9 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     await _mutex.acquire();
     emit(const ChatState.loading());
     _pot = event.pot;
-    _completer.complete();
+    if (!_completer.isCompleted) {
+      _completer.complete();
+    }
     try {
       final stream = emit.forEach(
         _chatRepository.getChatsStream(_pot),

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -146,24 +146,51 @@ class ChatRoomPage extends StatelessWidget with LogPage {
   }
 }
 
-class _Layout extends StatelessWidget {
+class _Layout extends StatefulWidget {
   const _Layout({required this.pot});
 
   final PotInfoEntity pot;
 
   @override
+  State<_Layout> createState() => _LayoutState();
+}
+
+class _LayoutState extends State<_Layout> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      final chatState = context.read<ChatBloc>().state;
+      if (!chatState.isLoading) {
+        context.read<ChatBloc>().add(ChatEvent.init(widget.pot));
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final disabled = pot.isArchived;
-    final banner = _buildBanner(context, pot);
+    final disabled = widget.pot.isArchived;
+    final banner = _buildBanner(context, widget.pot);
     return Scaffold(
       backgroundColor: disabled ? const Color(0xfff0f0f0) : null,
-      appBar: PotAppBar(title: Text(pot.name)),
+      appBar: PotAppBar(title: Text(widget.pot.name)),
       onEndDrawerChanged: (value) {
         if (value) {
           L.c('sidebar');
         }
       },
-      endDrawer: ChatRoomDrawer(pot: pot),
+      endDrawer: ChatRoomDrawer(pot: widget.pot),
       body: Column(
         children: [
           BlocBuilder<SocketAuthBloc, SocketAuthState>(
@@ -174,7 +201,7 @@ class _Layout extends StatelessWidget {
           Expanded(
             child: Stack(
               children: [
-                ChatList(pot: pot),
+                ChatList(pot: widget.pot),
                 if (banner != null)
                   Positioned(top: 20, left: 20, right: 20, child: banner),
               ],
@@ -185,8 +212,8 @@ class _Layout extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 6),
               child: Row(
                 children: [
-                  SetDepartureTimeButton(pot: pot),
-                  AccountingButton(pot: pot),
+                  SetDepartureTimeButton(pot: widget.pot),
+                  AccountingButton(pot: widget.pot),
                   Expanded(child: ChatInput()),
                 ],
               ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 블록 안정성 개선으로 예기치 않은 오류 방지
  * 앱이 백그라운드에서 돌아올 때 채팅 자동 새로고침 (로딩 중이 아닐 경우)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->