### PR TITLE
fix: tab after consent

### DIFF
--- a/lib/app/modules/core/presentation/bloc/hidden_menu_bloc.dart
+++ b/lib/app/modules/core/presentation/bloc/hidden_menu_bloc.dart
@@ -57,6 +57,8 @@ sealed class HiddenMenuState with _$HiddenMenuState {
   const factory HiddenMenuState.enabled(HiddenMenuLevel level) = _Enabled;
   const factory HiddenMenuState.disabled() = _Disabled;
 
+  bool get isInitial => this is _Initial;
+
   HiddenMenuLevel? get level => switch (this) {
     _Enabled(:final level) => level,
     _ => null,

--- a/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
+++ b/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
@@ -102,22 +102,18 @@ class _MainBottomNavigationPageState extends State<MainBottomNavigationPage>
             return;
           }
           if (index != 0 && context.read<AuthBloc>().state.user == null) {
-            final completer = Completer<bool>();
+            final completer = Completer<void>();
             context.router.push(
               LoginRoute(
-                onDone: () => completer.complete(true),
-                onConsent: () => context.router.popAndPush(
-                  ConsentRoute(onDone: () => completer.complete(true)),
-                ),
-                onCancel: () => completer.complete(false),
+                onDone: () => completer.complete(),
+                onConsent: () => completer.complete(),
+                onCancel: () => completer.complete(),
               ),
             );
-            final result = await completer.future;
+            await completer.future;
             if (!context.mounted) return;
             context.router.pop();
-            if (!result) return;
-          }
-          if (context.mounted) {
+          } else if (context.mounted) {
             AutoTabsRouter.of(context).setActiveIndex(index);
           }
         },

--- a/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
+++ b/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
@@ -28,61 +28,88 @@ class _MainBottomNavigationPageState extends State<MainBottomNavigationPage>
     return AutoTabsRouter.tabBar(
       physics: NeverScrollableScrollPhysics(),
       routes: [ListRoute(), ChatRoute(), ProfileRoute()],
-      builder: (context, child, tabController) {
-        final items = [
-          _Item(
-            icon: Assets.icons.addPot.svg(),
-            label: context.t.create.menu_title,
-            onTap: () => L.c('create'),
-          ),
-          _Item(
-            icon: Assets.icons.search.svg(),
-            label: context.t.list.title,
-            onTap: () => L.c('search'),
-          ),
-          _Item(
-            icon: Assets.icons.chatBubble.svg(),
-            label: context.t.chat.menu_title,
-            onTap: () => L.c('chatList'),
-          ),
-          _Item(
-            icon: Assets.icons.userCircle.svg(),
-            label: context.t.profile.menu_title,
-            onTap: () => L.c('profile'),
-          ),
-        ];
-        return Scaffold(
-          body: child,
-          bottomNavigationBar: Container(
-            color: Palette.white,
-            child: SafeArea(
-              child: Stack(
-                children: [
-                  Container(
-                    height: 0,
-                    decoration: BoxDecoration(
-                      border: Border(
-                        top: BorderSide(color: Palette.borderGrey2, width: 1),
-                      ),
-                    ),
+      builder: (context, child, tabController) =>
+          _Layout(tabController: tabController, child: child),
+    );
+  }
+}
+
+class _Layout extends StatefulWidget {
+  const _Layout({required this.tabController, required this.child});
+  final TabController tabController;
+  final Widget child;
+
+  @override
+  State<_Layout> createState() => _LayoutState();
+}
+
+class _LayoutState extends State<_Layout> {
+  static int? _lastIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (_lastIndex != null) {
+        widget.tabController.animateTo(_lastIndex!);
+        _lastIndex = null;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      _Item(
+        icon: Assets.icons.addPot.svg(),
+        label: context.t.create.menu_title,
+        onTap: () => L.c('create'),
+      ),
+      _Item(
+        icon: Assets.icons.search.svg(),
+        label: context.t.list.title,
+        onTap: () => L.c('search'),
+      ),
+      _Item(
+        icon: Assets.icons.chatBubble.svg(),
+        label: context.t.chat.menu_title,
+        onTap: () => L.c('chatList'),
+      ),
+      _Item(
+        icon: Assets.icons.userCircle.svg(),
+        label: context.t.profile.menu_title,
+        onTap: () => L.c('profile'),
+      ),
+    ];
+    return Scaffold(
+      body: widget.child,
+      bottomNavigationBar: Container(
+        color: Palette.white,
+        child: SafeArea(
+          child: Stack(
+            children: [
+              Container(
+                height: 0,
+                decoration: BoxDecoration(
+                  border: Border(
+                    top: BorderSide(color: Palette.borderGrey2, width: 1),
                   ),
-                  Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Row(
-                      children: items
-                          .mapIndexed(
-                            (index, item) =>
-                                _buildItem(context, index - 1, item),
-                          )
-                          .toList(),
-                    ),
-                  ),
-                ],
+                ),
               ),
-            ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: items
+                      .mapIndexed(
+                        (index, item) => _buildItem(context, index - 1, item),
+                      )
+                      .toList(),
+                ),
+              ),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 
@@ -113,6 +140,7 @@ class _MainBottomNavigationPageState extends State<MainBottomNavigationPage>
             await completer.future;
             if (!context.mounted) return;
             context.router.pop();
+            _lastIndex = index;
           } else if (context.mounted) {
             AutoTabsRouter.of(context).setActiveIndex(index);
           }

--- a/lib/app/pot_app.dart
+++ b/lib/app/pot_app.dart
@@ -187,6 +187,7 @@ class _Listeners extends StatelessWidget {
           },
         ),
         BlocListener<HiddenMenuBloc, HiddenMenuState>(
+          listenWhen: (prev, curr) => !prev.isInitial,
           listener: (context, state) {
             state.mapOrNull(
               enabled: (_) => context.showToast('Hidden menu enabled'),

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -31,9 +31,7 @@ class AppRouter extends RootStackRouter {
             user.agreedTerms.allRequired) {
           return resolver.next(true);
         }
-        await resolver.redirectUntil(
-          ConsentRoute(onDone: () => resolver.next(true)),
-        );
+        await resolver.redirectUntil(ConsentRoute(onDone: () {}));
         return;
       }
       if (resolver.route.name == MainBottomNavigationRoute.name ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pot_g
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
- **fix: skip initial hidden menu notification**
- **refactor: remove unnecessary completer type**
- **chore: bump version to 1.0.8**
- **fix: tab after consent**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 로그인 후 이전에 선택했던 탭이 자동으로 복구됩니다.
  * 상태 관리 로직을 개선하여 초기 알림 불필요한 발생을 줄였습니다.

* **버전**
  * v1.0.8로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->