### PR TITLE
fix: show account after accounting

### DIFF
--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -35,7 +35,8 @@ class ChatRoomDrawer extends StatelessWidget {
               const SizedBox(height: 20),
               Container(height: 1, color: Palette.borderGrey2),
               const SizedBox(height: 20),
-              if (pot.status == PotStatus.waitAccounting)
+              if (pot.status >= PotStatus.waitAccounting &&
+                  pot.accountingInfo.costPerUser != null)
                 PotAccounting(pot: pot)
               else
                 PotUsers(pot: pot),

--- a/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
+++ b/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
@@ -141,7 +141,8 @@ class _LayoutState extends State<_Layout> {
             if (!context.mounted) return;
             context.router.pop();
             _lastIndex = index;
-          } else if (context.mounted) {
+          }
+          if (context.mounted) {
             AutoTabsRouter.of(context).setActiveIndex(index);
           }
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회계 정보가 필요할 때만 정확하게 표시되도록 개선되었습니다.
  * 로그인 후 탭 내비게이션이 더욱 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->