### PR TITLE
fix: sort pot list

### DIFF
--- a/lib/app/modules/list/presentation/bloc/pot_list_bloc.dart
+++ b/lib/app/modules/list/presentation/bloc/pot_list_bloc.dart
@@ -45,10 +45,10 @@ class PotListBloc extends Bloc<PotListEvent, PotListState> {
       );
       emit(
         state.copyWith(
-          pots: [
-            ...state.pots,
-            ...pots,
-          ].sorted((a, b) => a.total == a.current ? 1 : 0),
+          pots: [...state.pots, ...pots].sorted(
+            (a, b) =>
+                (a.total == a.current ? 1 : 0) - (b.total == b.current ? 1 : 0),
+          ),
           isLoading: false,
           endReached: pots.length < 100,
         ),

--- a/lib/app/modules/list/presentation/bloc/pot_list_bloc.dart
+++ b/lib/app/modules/list/presentation/bloc/pot_list_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
@@ -44,7 +45,10 @@ class PotListBloc extends Bloc<PotListEvent, PotListState> {
       );
       emit(
         state.copyWith(
-          pots: [...state.pots, ...pots],
+          pots: [
+            ...state.pots,
+            ...pots,
+          ].sorted((a, b) => a.total == a.current ? 1 : 0),
           isLoading: false,
           endReached: pots.length < 100,
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 포트 목록의 정렬 순서를 개선했습니다. 진행 중인 포트가 완료된 포트보다 먼저 표시되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->