### PR TITLE
fix: prevent tab transition after cancel login

### DIFF
--- a/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
+++ b/lib/app/modules/main/presentation/pages/main_bottom_navigation_page.dart
@@ -129,18 +129,19 @@ class _LayoutState extends State<_Layout> {
             return;
           }
           if (index != 0 && context.read<AuthBloc>().state.user == null) {
-            final completer = Completer<void>();
+            final completer = Completer<int?>();
             context.router.push(
               LoginRoute(
-                onDone: () => completer.complete(),
-                onConsent: () => completer.complete(),
-                onCancel: () => completer.complete(),
+                onDone: () => completer.complete(index),
+                onConsent: () => completer.complete(index),
+                onCancel: () => completer.complete(null),
               ),
             );
-            await completer.future;
+            final result = await completer.future;
             if (!context.mounted) return;
             context.router.pop();
-            _lastIndex = index;
+            _lastIndex = result;
+            if (result == null) return;
           }
           if (context.mounted) {
             AutoTabsRouter.of(context).setActiveIndex(index);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 플로우 완료 후 선택된 네비게이션 항목이 올바르게 유지되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->