### PR TITLE
fix: fetch chats without any condition initially

### DIFF
--- a/lib/app/modules/chat/data/models/get_pot_events_query_model.dart
+++ b/lib/app/modules/chat/data/models/get_pot_events_query_model.dart
@@ -8,7 +8,7 @@ part 'get_pot_events_query_model.g.dart';
 sealed class GetPotEventsQueryModel with _$GetPotEventsQueryModel {
   const factory GetPotEventsQueryModel({
     @Default(20) int? limit,
-    @EpochDateTimeConverter() required DateTime startsFrom,
+    @EpochDateTimeConverter() DateTime? startsFrom,
     int? except,
   }) = _GetPotEventsQueryModel;
 }

--- a/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_chat_repository.dart
@@ -112,10 +112,7 @@ class WebsocketChatRepository implements ChatRepository {
     final localPot = await _api.getPotInfo(pot.id);
     final events = await _api.getPotEvents(
       pot.id,
-      GetPotEventsQueryModel(
-        startsFrom: last?.createdAt ?? DateTime.now(),
-        except: last?.id,
-      ),
+      GetPotEventsQueryModel(startsFrom: last?.createdAt, except: last?.id),
     );
     return events.events
         .where((e) => e.potPk == pot.id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 메시지 조회 시 시간 범위 필터링 매개변수를 선택적으로 변경했습니다. 이전 메시지가 없을 때 현재 시간을 기본값으로 사용하던 방식을 제거하여, 채팅 검색 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->