### PR TITLE
feat: make chat text selectable

### DIFF
--- a/lib/app/modules/chat/presentation/widgets/chat_bubble.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_bubble.dart
@@ -32,7 +32,7 @@ class ChatBubble extends StatelessWidget {
           ? null
           : PotProfileImage(user: user!, pot: pot),
       name: user?.name,
-      child: Text(
+      child: SelectableText(
         message,
         style: TextStyles.description.copyWith(
           color: user == null ? Palette.primaryLight : Palette.textGrey,

--- a/lib/app/modules/chat/presentation/widgets/fofo_bubble.dart
+++ b/lib/app/modules/chat/presentation/widgets/fofo_bubble.dart
@@ -53,12 +53,12 @@ class FofoBubble extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
+          SelectableText(
             message.content.split('\n').first.replaceAll('**', '').trim(),
             style: TextStyles.title4.copyWith(color: Palette.textGrey),
           ),
           const SizedBox(height: 8),
-          Text(
+          SelectableText(
             message.content.split('\n').sublist(1).join('\n').trim(),
             style: TextStyles.description.copyWith(color: Palette.textGrey),
           ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 채팅 메시지 텍스트 선택 기능: 모든 채팅 버블의 텍스트를 선택하여 복사할 수 있게 되었습니다. 제목 줄과 설명 텍스트 모두에서 텍스트를 선택할 수 있으며, 레이아웃과 스타일은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->