### PR TITLE
fix: rename `name` -> `potName` for pot name property

### DIFF
--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -192,7 +192,7 @@ class _LayoutState extends State<_Layout> with WidgetsBindingObserver {
         if (value) {
           L.c(
             'sidebar',
-            properties: {'potId': widget.pot.id, 'name': widget.pot.name},
+            properties: {'potId': widget.pot.id, 'potName': widget.pot.name},
           );
         }
       },

--- a/lib/app/modules/chat/presentation/widgets/accounting_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/accounting_button.dart
@@ -119,7 +119,7 @@ class _AccountingButtonState extends State<AccountingButton> {
     if (!mounted) return;
     L.c(
       'accounting',
-      properties: {'potId': widget.pot.id, 'name': widget.pot.name},
+      properties: {'potId': widget.pot.id, 'potName': widget.pot.name},
     );
     await AccountingButton.setAccounting(context, widget.pot);
   }

--- a/lib/app/modules/chat/presentation/widgets/chat_input.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_input.dart
@@ -81,7 +81,7 @@ class _ChatInputState extends State<ChatInput> {
                     final pot = context.read<PotInfoBloc>().state.pot;
                     L.c(
                       'sendMessage',
-                      properties: {'potId': pot?.id, 'name': pot?.name},
+                      properties: {'potId': pot?.id, 'potName': pot?.name},
                     );
                     context.read<ChatBloc>().add(
                       ChatSendChat(_controller.text.trim()),

--- a/lib/app/modules/chat/presentation/widgets/chat_list.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list.dart
@@ -170,7 +170,7 @@ class _ChatListState extends State<ChatList> {
   }
 
   void _onAction(BuildContext context, FofoActionButtonType type) async {
-    final l = LL({'potId': widget.pot.id, 'name': widget.pot.name});
+    final l = LL({'potId': widget.pot.id, 'potName': widget.pot.name});
     switch (type) {
       case FofoActionButtonType.departureConfirm:
         l.c('fofoSetDepartureTime');

--- a/lib/app/modules/chat/presentation/widgets/chat_list_item.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list_item.dart
@@ -46,7 +46,7 @@ class ChatListItem extends StatelessWidget {
 
     return PotPressable(
       onTap: () {
-        L.c('chatRoom', properties: {'potId': pot.id, 'name': pot.name});
+        L.c('chatRoom', properties: {'potId': pot.id, 'potName': pot.name});
         ChatRoomRoute(id: pot.id).push(context);
       },
       child: Container(

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -65,7 +65,7 @@ class ChatRoomDrawer extends StatelessWidget {
   }
 
   Future<void> _leave(BuildContext context) async {
-    L.c('leave', properties: {'potId': pot.id, 'name': pot.name});
+    L.c('leave', properties: {'potId': pot.id, 'potName': pot.name});
     if (pot.departureTime != null) {
       showOkAlertDialog(
         context: context,

--- a/lib/app/modules/chat/presentation/widgets/pot_users.dart
+++ b/lib/app/modules/chat/presentation/widgets/pot_users.dart
@@ -53,7 +53,7 @@ class PotUsers extends StatelessWidget {
                         properties: {
                           'userId': e.id,
                           'potId': pot.id,
-                          'name': pot.name,
+                          'potName': pot.name,
                         },
                       );
                       _kickUser(context, e);
@@ -65,7 +65,7 @@ class PotUsers extends StatelessWidget {
         ),
         PotPressable(
           onTap: () {
-            L.c('copyLink', properties: {'potId': pot.id, 'name': pot.name});
+            L.c('copyLink', properties: {'potId': pot.id, 'potName': pot.name});
             final inviteText = context.t.chat_room.drawer.members.invite;
             if (pot.departureTime != null) {
               showOkAlertDialog(

--- a/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
@@ -29,7 +29,7 @@ class SetDepartureTimeButton extends StatefulWidget {
     BuildContext context,
     PotInfoEntity pot,
   ) async {
-    final l = LL({'potId': pot.id, 'name': pot.name});
+    final l = LL({'potId': pot.id, 'potName': pot.name});
     if (!pot.meIsHost(context)) {
       context.showToast(
         context.t.chat_room.set_departure_time.host_only.description,
@@ -157,7 +157,7 @@ class _SetDepartureTimeButtonState extends State<SetDepartureTimeButton> {
     if (!mounted) return;
     L.c(
       'setDepartureTime',
-      properties: {'potId': widget.pot.id, 'name': widget.pot.name},
+      properties: {'potId': widget.pot.id, 'potName': widget.pot.name},
     );
     await SetDepartureTimeButton.setDepartureTime(context, widget.pot);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 채팅 모듈의 로깅 체계를 개선했습니다. 여러 화면과 위젯에서 로깅 데이터의 키를 일관성 있게 업데이트하여 내부 추적 및 분석 정확성을 향상시켰습니다. 사용자 기능에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->