### PR TITLE
Fix can't submit if NaN is in the account number

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -63,6 +63,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "akrnwl",
+      "name": "akrnwl",
+      "avatar_url": "https://avatars.githubusercontent.com/u/117907042?v=4",
+      "profile": "https://github.com/akrnwl",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.ko.md
+++ b/README.ko.md
@@ -77,6 +77,7 @@ lib/
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Yejin-02"><img src="https://avatars.githubusercontent.com/u/110380670?v=4?s=100" width="100px;" alt="Yejin-02"/><br /><sub><b>Yejin-02</b></sub></a><br /><a href="#design-Yejin-02" title="Design">🎨</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/BranKein"><img src="https://avatars.githubusercontent.com/u/32633156?v=4?s=100" width="100px;" alt="YeonhyukKim"/><br /><sub><b>YeonhyukKim</b></sub></a><br /><a href="https://github.com/gsainfoteam/pot-g-flutter/commits?author=BranKein" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/enc2586"><img src="https://avatars.githubusercontent.com/u/85762538?v=4?s=100" width="100px;" alt="Hongje Choi"/><br /><sub><b>Hongje Choi</b></sub></a><br /><a href="#translation-enc2586" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/akrnwl"><img src="https://avatars.githubusercontent.com/u/117907042?v=4?s=100" width="100px;" alt="akrnwl"/><br /><sub><b>akrnwl</b></sub></a><br /><a href="https://github.com/gsainfoteam/pot-g-flutter/commits?author=akrnwl" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Thanks goes to these wonderful people
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Yejin-02"><img src="https://avatars.githubusercontent.com/u/110380670?v=4?s=100" width="100px;" alt="Yejin-02"/><br /><sub><b>Yejin-02</b></sub></a><br /><a href="#design-Yejin-02" title="Design">🎨</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/BranKein"><img src="https://avatars.githubusercontent.com/u/32633156?v=4?s=100" width="100px;" alt="YeonhyukKim"/><br /><sub><b>YeonhyukKim</b></sub></a><br /><a href="https://github.com/gsainfoteam/pot-g-flutter/commits?author=BranKein" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/enc2586"><img src="https://avatars.githubusercontent.com/u/85762538?v=4?s=100" width="100px;" alt="Hongje Choi"/><br /><sub><b>Hongje Choi</b></sub></a><br /><a href="#translation-enc2586" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/akrnwl"><img src="https://avatars.githubusercontent.com/u/117907042?v=4?s=100" width="100px;" alt="akrnwl"/><br /><sub><b>akrnwl</b></sub></a><br /><a href="https://github.com/gsainfoteam/pot-g-flutter/commits?author=akrnwl" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intersperse/intersperse.dart';
 import 'package:pot_g/app/di/locator.dart';
@@ -416,6 +417,7 @@ class _BankNumberState extends State<_BankNumber> {
               filled: true,
               controller: controller,
               keyboardType: TextInputType.none,
+              inputFormatters: const [DigitsOnlyFormatter(maxLength: 20)],
               hintText: context
                   .t
                   .profile
@@ -458,5 +460,35 @@ extension on List<BankEntity> {
       result.add(sublist(i, min(i + size, length)));
     }
     return result;
+  }
+}
+
+class DigitsOnlyFormatter extends TextInputFormatter {
+  const DigitsOnlyFormatter({this.maxLength});
+  final int? maxLength;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final normalized = newValue.text.replaceAllMapped(RegExp(r'[０-９]'), (m) {
+      return String.fromCharCode(m[0]!.codeUnitAt(0) - 0xFEE0);
+    });
+
+    // 숫자만 남기기
+    var digits = normalized.replaceAll(RegExp(r'[^0-9]'), '');
+
+    // 길이 제한(옵션)
+    if (maxLength != null && digits.length > maxLength!) {
+      digits = digits.substring(0, maxLength);
+    }
+
+    // 커서는 끝으로 이동(단순 접근)
+    return TextEditingValue(
+      text: digits,
+      selection: TextSelection.collapsed(offset: digits.length),
+      composing: TextRange.empty,
+    );
   }
 }

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -476,15 +476,12 @@ class DigitsOnlyFormatter extends TextInputFormatter {
       return String.fromCharCode(m[0]!.codeUnitAt(0) - 0xFEE0);
     });
 
-    // 숫자만 남기기
     var digits = normalized.replaceAll(RegExp(r'[^0-9]'), '');
 
-    // 길이 제한(옵션)
     if (maxLength != null && digits.length > maxLength!) {
       digits = digits.substring(0, maxLength);
     }
 
-    // 커서는 끝으로 이동(단순 접근)
     return TextEditingValue(
       text: digits,
       selection: TextSelection.collapsed(offset: digits.length),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pot_g
 description: "A new Flutter project."
-publish_to: 'none'
-version: 1.0.18
+publish_to: "none"
+version: 1.0.19
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
DigitsOnlyFormatter class를 account_number_settings_page.dart 내부에 구현하여 계좌번호를 복사 붙여넣기를 했을 때 digits만 붙여넣을 수 있도록 설정하였습니다.

+ 기존에 키보드로 digits만 입력할 수 있었기에 예상치 못한 경로(복붙)만 대처하면 될 것으로 생각했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 번호 입력 필드에 숫자 전용 입력 제한이 추가되었습니다. 전각 숫자는 자동 변환되며 숫자 외 문자는 제거되고 최대 20자까지 입력됩니다.

* **문서**
  * README 및 기여자 설정에 새로운 기여자 항목이 추가되었습니다.

* **잡일**
  * 패키지 버전이 1.0.19로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a digit-only input formatter to the account number field (normalizes full-width digits, strips non-digits, max 20), plus contributor and version updates.
> 
> - **User Settings – Account Number Input**
>   - Add `DigitsOnlyFormatter` in `lib/app/modules/user/presentation/pages/account_number_settings_page.dart` to normalize full-width digits, remove non-digits, and cap length at 20.
>   - Apply formatter via `inputFormatters` to the `PotTextField` for bank account entry.
> - **Docs**
>   - Add contributor `akrnwl` in `.all-contributorsrc`, `README.md`, and `README.ko.md`.
> - **Chore**
>   - Bump app version to `1.0.19` in `pubspec.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b27828614b0313a1a19208bbcfd0bcd9e55c54ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->