### PR TITLE
feat: new design for pot list

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -139,6 +139,7 @@
       "description": "The maximum number of people who can join the pot",
       "fields": {
         "max_capacity": {
+          "label": "Capacity",
           "item": {
             "one": "$n person",
             "other": "$n people"

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -139,6 +139,7 @@
       "description": "택시팟의 최대 인원 수를 설정하세요",
       "fields": {
         "max_capacity": {
+          "label": "정원",
           "item": "$n명"
         }
       }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - flutter_web_auth_2 (3.0.0):
+  - flutter_web_auth_2 (5.0.0-alpha.2):
     - Flutter
   - GoogleAdsOnDeviceConversion (2.1.0):
     - GoogleUtilities/Logger (~> 8.1)
@@ -289,7 +289,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80
+  flutter_web_auth_2: c35a99b4799ad94b0dc140880f406cf59a4af866
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
   GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -207,7 +207,7 @@ class _LayoutState extends State<_Layout> with WidgetsBindingObserver {
           Expanded(
             child: Stack(
               children: [
-                ChatList(pot: widget.pot),
+                ChatList(pot: widget.pot, bannerShown: banner != null),
                 if (banner != null)
                   Positioned(top: 20, left: 20, right: 20, child: banner),
               ],

--- a/lib/app/modules/chat/presentation/widgets/chat_list.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list.dart
@@ -26,9 +26,10 @@ import 'package:pot_g/app/values/text_styles.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
 class ChatList extends StatefulWidget {
-  const ChatList({super.key, required this.pot});
+  const ChatList({super.key, required this.pot, required this.bannerShown});
 
   final PotInfoEntity pot;
+  final bool bannerShown;
 
   @override
   State<ChatList> createState() => _ChatListState();
@@ -89,7 +90,10 @@ class _ChatListState extends State<ChatList> {
           physics: const AlwaysScrollableScrollPhysics(),
           controller: _controller,
           reverse: true,
-          padding: const EdgeInsets.all(12) - EdgeInsets.only(right: 6),
+          padding:
+              const EdgeInsets.all(12) -
+              EdgeInsets.only(right: 6) +
+              EdgeInsets.only(top: widget.bannerShown ? 72 : 0),
           separatorBuilder: (context, index) =>
               SizedBox(height: isLast(index) ? 12 : 6),
           itemBuilder: (context, index) => index == state.chats.length

--- a/lib/app/modules/chat/presentation/widgets/chat_list.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_list.dart
@@ -81,7 +81,8 @@ class _ChatListState extends State<ChatList> {
           final nextChat = index == state.chats.length - 1
               ? null
               : state.chats[index + 1];
-          return nextChat?.createdAt.isSameDay(chat.createdAt) == false;
+          if (nextChat == null) return true;
+          return !nextChat.createdAt.isSameDay(chat.createdAt);
         }
 
         return ListView.separated(
@@ -89,31 +90,40 @@ class _ChatListState extends State<ChatList> {
           controller: _controller,
           reverse: true,
           padding: const EdgeInsets.all(12) - EdgeInsets.only(right: 6),
-          separatorBuilder: (context, index) => dateChanged(index)
-              ? Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  child: Center(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        vertical: 4,
-                        horizontal: 16,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Palette.lightGrey,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Text(
-                        DateFormat.yMd().add_E().format(
-                          state.chats[index].createdAt,
+          separatorBuilder: (context, index) =>
+              SizedBox(height: isLast(index) ? 12 : 6),
+          itemBuilder: (context, index) => index == state.chats.length
+              ? const Center(child: CircularProgressIndicator.adaptive())
+              : Column(
+                  children: [
+                    if (dateChanged(index))
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: Center(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 4,
+                              horizontal: 16,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Palette.lightGrey,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(
+                              DateFormat.yMd().add_E().format(
+                                state.chats[index].createdAt,
+                              ),
+                              textAlign: TextAlign.center,
+                              style: TextStyles.caption.copyWith(
+                                color: Palette.grey,
+                              ),
+                            ),
+                          ),
                         ),
-                        textAlign: TextAlign.center,
-                        style: TextStyles.caption.copyWith(color: Palette.grey),
                       ),
-                    ),
-                  ),
-                )
-              : SizedBox(height: isLast(index) ? 12 : 6),
-          itemBuilder: (context, index) => _buildItem(context, index, state),
+                    _buildItem(context, index, state),
+                  ],
+                ),
           itemCount: state.chats.length + (state.isLoading ? 1 : 0),
         );
       },
@@ -132,9 +142,6 @@ class _ChatListState extends State<ChatList> {
       return nextChat.user.id != chat.user.id;
     }
 
-    if (index == state.chats.length) {
-      return const Center(child: CircularProgressIndicator.adaptive());
-    }
     final chat = state.chats[index];
     if (chat is! ChatEntity) {
       if (chat is SystemMessageEntity) {

--- a/lib/app/modules/list/presentation/pages/list_page.dart
+++ b/lib/app/modules/list/presentation/pages/list_page.dart
@@ -1,7 +1,9 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
 import 'package:pot_g/app/di/locator.dart';
+import 'package:pot_g/app/modules/common/presentation/extensions/date_time.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log_page.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_app_bar.dart';
@@ -145,9 +147,32 @@ class _ListViewState extends State<_ListView> {
         itemCount: widget.pots.length + 1, // +1 for loading indicator
         itemBuilder: (context, index) {
           if (index < widget.pots.length) {
+            final pot = widget.pots[index];
+            final previousPot = index > 0 ? widget.pots[index - 1] : null;
+            final isSameDay = previousPot == null
+                ? false
+                : pot.startsAt.isSameDay(previousPot.startsAt);
+            final version = 2;
             return Column(
               children: [
-                PotListItem(pot: widget.pots[index]),
+                if (!isSameDay && version >= 2) ...[
+                  Row(
+                    children: [
+                      Text(
+                        DateFormat.yMd().add_E().format(pot.startsAt),
+                        style: TextStyles.caption.copyWith(
+                          color: Palette.textGrey,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Container(height: 1, color: Palette.textGrey),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                PotListItem(pot: pot),
                 const SizedBox(height: 15),
               ],
             );

--- a/lib/app/modules/list/presentation/pages/list_page.dart
+++ b/lib/app/modules/list/presentation/pages/list_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
@@ -152,7 +153,7 @@ class _ListViewState extends State<_ListView> {
             final isSameDay = previousPot == null
                 ? false
                 : pot.startsAt.isSameDay(previousPot.startsAt);
-            final version = 2;
+            final version = kDebugMode ? 2 : 1;
             return Column(
               children: [
                 if (!isSameDay && version >= 2) ...[

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -12,6 +12,9 @@ import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/app/values/text_styles.dart';
 import 'package:pot_g/gen/strings.g.dart';
 
+const _lineWidth = 1.0;
+const _radius = 5.0;
+
 class PotListItem extends StatelessWidget {
   const PotListItem({super.key, required this.pot});
 
@@ -226,14 +229,14 @@ class _ItemV2 extends StatelessWidget {
                 ),
               ),
               Padding(
-                padding: EdgeInsets.symmetric(vertical: 5),
+                padding: EdgeInsets.symmetric(vertical: _radius),
                 child: CustomPaint(
                   foregroundPainter: _DashedLinePainter(
                     dashWidth: 4,
                     dashSpace: 4,
                     startY: 0,
                   ),
-                  child: Container(width: 1),
+                  child: Container(width: _lineWidth),
                 ),
               ),
               ClipPath(
@@ -312,8 +315,8 @@ class _DashedLinePainter extends CustomPainter {
 
 class _HoleClipper extends CustomClipper<Path> {
   final bool isLeft;
-  final double radius = 5;
-  final double gap = 1;
+  final double radius = _radius;
+  final double gap = _lineWidth;
   _HoleClipper({required this.isLeft});
   @override
   Path getClip(Size size) {

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -19,6 +19,7 @@ class PotListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final version = 2;
     return PotPressable(
       onTap: pot.disabled
           ? null
@@ -26,7 +27,7 @@ class PotListItem extends StatelessWidget {
               L.c('pot', properties: {'potId': pot.id, 'potName': pot.name});
               InvitedRoute(id: pot.id).push(context);
             },
-      child: 2 == 1 ? _ItemV1(pot: pot) : _ItemV2(pot: pot),
+      child: version == 1 ? _ItemV1(pot: pot) : _ItemV2(pot: pot),
     );
   }
 }

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -325,7 +325,10 @@ class _DashedLinePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_DashedLinePainter oldDelegate) => false;
+  bool shouldRepaint(_DashedLinePainter oldDelegate) =>
+      oldDelegate.dashWidth != dashWidth ||
+      oldDelegate.dashSpace != dashSpace ||
+      oldDelegate.startY != startY;
 }
 
 class _HoleClipper extends CustomClipper<Path> {
@@ -359,7 +362,10 @@ class _HoleClipper extends CustomClipper<Path> {
   }
 
   @override
-  bool shouldReclip(_HoleClipper oldClipper) => true;
+  bool shouldReclip(_HoleClipper oldClipper) =>
+      oldClipper.isLeft != isLeft ||
+      oldClipper.radius != radius ||
+      oldClipper.gap != gap;
 }
 
 extension on PotSummaryEntity {

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -84,7 +84,10 @@ class _ItemV1 extends StatelessWidget {
               ],
             ),
           ),
-          CustomPaint(size: Size(1, 88), painter: _DashedLinePainter()),
+          CustomPaint(
+            size: Size(1, 88),
+            painter: _DashedLinePainter(dashWidth: 4, dashSpace: 4, startY: 0),
+          ),
           Expanded(
             child: Container(
               padding: EdgeInsets.all(12),
@@ -174,49 +177,59 @@ class _ItemV2 extends StatelessWidget {
           child: Row(
             children: [
               Expanded(
-                child: Container(
-                  padding: EdgeInsets.symmetric(vertical: 14, horizontal: 12),
-                  color: Palette.white,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        pot.route.name,
-                        style: TextStyles.description.copyWith(
-                          color: pot.disabled ? Palette.grey : Palette.textGrey,
+                child: ClipPath(
+                  child: Container(
+                    padding: EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+                    color: Palette.white,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          pot.route.name,
+                          style: TextStyles.description.copyWith(
+                            color: pot.disabled
+                                ? Palette.grey
+                                : Palette.textGrey,
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 7),
-                      Text.rich(
-                        TextSpan(
-                          children: [
-                            TextSpan(
-                              text: DateFormat.Hm().format(pot.startsAt),
-                            ),
-                            TextSpan(text: '~'),
-                            TextSpan(text: DateFormat.Hm().format(pot.endsAt)),
-                            TextSpan(
-                              text: 'D+1',
-                              style: TextStyles.description.copyWith(
-                                fontSize: 12,
-
-                                color: pot.disabled
-                                    ? Palette.grey
-                                    : Palette.textGrey,
+                        const SizedBox(height: 7),
+                        Text.rich(
+                          TextSpan(
+                            children: [
+                              TextSpan(
+                                text: DateFormat.Hm().format(pot.startsAt),
                               ),
-                            ),
-                          ],
+                              TextSpan(text: '~'),
+                              TextSpan(
+                                text: DateFormat.Hm().format(pot.endsAt),
+                              ),
+                              TextSpan(
+                                text: 'D+1',
+                                style: TextStyles.description.copyWith(
+                                  fontSize: 12,
+
+                                  color: pot.disabled
+                                      ? Palette.grey
+                                      : Palette.textGrey,
+                                ),
+                              ),
+                            ],
+                          ),
+                          style: TextStyles.title3.copyWith(
+                            color: pot.disabled ? Palette.grey : Palette.dark,
+                          ),
                         ),
-                        style: TextStyles.title3.copyWith(
-                          color: pot.disabled ? Palette.grey : Palette.dark,
-                        ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),
               CustomPaint(
-                foregroundPainter: _DashedLinePainter(),
+                foregroundPainter: _DashedLinePainter(
+                  dashWidth: 4,
+                  dashSpace: 4,
+                  startY: 0,
+                ),
                 child: Container(width: 8),
               ),
               Container(
@@ -249,9 +262,17 @@ class _ItemV2 extends StatelessWidget {
 }
 
 class _DashedLinePainter extends CustomPainter {
+  final double dashWidth;
+  final double dashSpace;
+  final double startY;
+  _DashedLinePainter({
+    required this.dashWidth,
+    required this.dashSpace,
+    required this.startY,
+  });
   @override
   void paint(Canvas canvas, Size size) {
-    double dashWidth = 4, dashSpace = 4, startY = 0;
+    double startY = this.startY;
     canvas.drawRect(
       Offset.zero & Size(size.width / 2, size.height),
       Paint()..color = Palette.white,
@@ -277,7 +298,7 @@ class _DashedLinePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(CustomPainter oldDelegate) => false;
+  bool shouldRepaint(_DashedLinePainter oldDelegate) => false;
 }
 
 extension on PotSummaryEntity {

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -6,9 +6,11 @@ import 'package:pot_g/app/modules/common/presentation/extensions/date_time.dart'
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/pot_pressable.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_summary_entity.dart';
+import 'package:pot_g/app/modules/core/domain/entities/route_entity.dart';
 import 'package:pot_g/app/router.gr.dart';
 import 'package:pot_g/app/values/palette.dart';
 import 'package:pot_g/app/values/text_styles.dart';
+import 'package:pot_g/gen/strings.g.dart';
 
 class PotListItem extends StatelessWidget {
   const PotListItem({super.key, required this.pot});
@@ -17,119 +19,224 @@ class PotListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final disabled = pot.current == pot.total;
     return PotPressable(
-      onTap: disabled
+      onTap: pot.disabled
           ? null
           : () {
               L.c('pot', properties: {'potId': pot.id, 'potName': pot.name});
               InvitedRoute(id: pot.id).push(context);
             },
-      child: Container(
-        height: 88,
-        decoration: BoxDecoration(
-          color: Palette.white,
-          borderRadius: BorderRadius.all(Radius.circular(10)),
-          boxShadow: [
-            BoxShadow(
-              offset: Offset(3, 1),
-              blurRadius: 8,
-              color: Color(0x14000000),
+      child: 2 == 1 ? _ItemV1(pot: pot) : _ItemV2(pot: pot),
+    );
+  }
+}
+
+class _ItemV1 extends StatelessWidget {
+  const _ItemV1({required this.pot});
+  final PotSummaryEntity pot;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 88,
+      decoration: BoxDecoration(
+        color: Palette.white,
+        borderRadius: BorderRadius.all(Radius.circular(10)),
+        boxShadow: [
+          BoxShadow(
+            offset: Offset(3, 1),
+            blurRadius: 8,
+            color: Color(0x14000000),
+          ),
+          BoxShadow(
+            offset: Offset(1, 3),
+            blurRadius: 8,
+            color: Color(0x14000000),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            width: 64,
+            decoration: BoxDecoration(
+              color: pot.disabled ? Palette.white : Palette.lightGrey,
+              borderRadius: BorderRadius.horizontal(left: Radius.circular(10)),
             ),
-            BoxShadow(
-              offset: Offset(1, 3),
-              blurRadius: 8,
-              color: Color(0x14000000),
-            ),
-          ],
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Container(
-              width: 64,
-              decoration: BoxDecoration(
-                color: disabled ? Palette.white : Palette.lightGrey,
-                borderRadius: BorderRadius.horizontal(
-                  left: Radius.circular(10),
-                ),
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    pot.name.substring(0, 2),
-                    style: TextStyles.title3.copyWith(
-                      color: disabled ? Palette.grey : Palette.textGrey,
-                    ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  pot.name.substring(0, 2),
+                  style: TextStyles.title3.copyWith(
+                    color: pot.disabled ? Palette.grey : Palette.textGrey,
                   ),
-                  const SizedBox(height: 4),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  pot.name.substring(2),
+                  style: TextStyles.description.copyWith(
+                    color: pot.disabled ? Palette.grey : Palette.textGrey,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          CustomPaint(size: Size(1, 88), painter: _DashedLinePainter()),
+          Expanded(
+            child: Container(
+              padding: EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        DateFormat.Md().add_E().format(pot.startsAt),
+                        style: TextStyles.caption.copyWith(
+                          color: pot.disabled ? Palette.grey : Palette.textGrey,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      DefaultTextStyle.merge(
+                        style: TextStyles.title1.copyWith(
+                          color: pot.disabled ? Palette.grey : Palette.dark,
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(DateFormat.Hm().format(pot.startsAt)),
+                            Text('~'),
+                            Text(DateFormat.Hm().format(pot.endsAt)),
+                            if (!pot.startsAt.isSameDay(pot.endsAt))
+                              Text(
+                                'D+1',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                  height: 0.66,
+                                  letterSpacing: -0.025 * 12,
+                                  color: pot.disabled
+                                      ? Palette.grey
+                                      : Palette.textGrey,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  Spacer(),
                   Text(
-                    pot.name.substring(2),
-                    style: TextStyles.description.copyWith(
-                      color: disabled ? Palette.grey : Palette.textGrey,
+                    '${pot.current}/${pot.total}',
+                    style: TextStyles.title1.copyWith(
+                      color: pot.disabled ? Palette.grey : Palette.primary,
                     ),
                   ),
                 ],
               ),
             ),
-            CustomPaint(size: Size(1, 88), painter: _DashedLinePainter()),
-            Expanded(
-              child: Container(
-                padding: EdgeInsets.all(12),
-                child: Row(
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ItemV2 extends StatelessWidget {
+  const _ItemV2({required this.pot});
+  final PotSummaryEntity pot;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.all(Radius.circular(10)),
+        boxShadow: [
+          BoxShadow(
+            offset: Offset(3, 2),
+            blurRadius: 4,
+            color: Color(0x0D000000),
+          ),
+          BoxShadow(
+            offset: Offset(-1, -1),
+            blurRadius: 6,
+            color: Color(0x09000000),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(10)),
+        child: IntrinsicHeight(
+          child: Row(
+            children: [
+              Expanded(
+                child: Container(
+                  padding: EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+                  color: Palette.white,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        pot.route.name,
+                        style: TextStyles.description.copyWith(
+                          color: pot.disabled ? Palette.grey : Palette.textGrey,
+                        ),
+                      ),
+                      const SizedBox(height: 7),
+                      Text.rich(
+                        TextSpan(
+                          children: [
+                            TextSpan(
+                              text: DateFormat.Hm().format(pot.startsAt),
+                            ),
+                            TextSpan(text: '~'),
+                            TextSpan(text: DateFormat.Hm().format(pot.endsAt)),
+                            TextSpan(
+                              text: 'D+1',
+                              style: TextStyles.description.copyWith(
+                                fontSize: 12,
+
+                                color: pot.disabled
+                                    ? Palette.grey
+                                    : Palette.textGrey,
+                              ),
+                            ),
+                          ],
+                        ),
+                        style: TextStyles.title3.copyWith(
+                          color: pot.disabled ? Palette.grey : Palette.dark,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Container(
+                color: Palette.primaryLight,
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          DateFormat.Md().add_E().format(pot.startsAt),
-                          style: TextStyles.caption.copyWith(
-                            color: disabled ? Palette.grey : Palette.textGrey,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        DefaultTextStyle.merge(
-                          style: TextStyles.title1.copyWith(
-                            color: disabled ? Palette.grey : Palette.dark,
-                          ),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            children: [
-                              Text(DateFormat.Hm().format(pot.startsAt)),
-                              Text('~'),
-                              Text(DateFormat.Hm().format(pot.endsAt)),
-                              if (!pot.startsAt.isSameDay(pot.endsAt))
-                                Text(
-                                  'D+1',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w500,
-                                    height: 0.66,
-                                    letterSpacing: -0.025 * 12,
-                                    color: disabled
-                                        ? Palette.grey
-                                        : Palette.textGrey,
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    Spacer(),
                     Text(
-                      '${pot.current}/${pot.total}',
-                      style: TextStyles.title1.copyWith(
-                        color: disabled ? Palette.grey : Palette.primary,
+                      context.t.create.capacity.fields.max_capacity.item(
+                        n: pot.current,
+                      ),
+                      style: TextStyles.title3.copyWith(color: Palette.primary),
+                    ),
+                    Text(
+                      '/${context.t.create.capacity.fields.max_capacity.item(n: pot.total)}',
+                      style: TextStyles.caption.copyWith(
+                        color: Palette.textGrey,
                       ),
                     ),
                   ],
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -159,4 +266,8 @@ class _DashedLinePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(CustomPainter oldDelegate) => false;
+}
+
+extension on PotSummaryEntity {
+  bool get disabled => current == total;
 }

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -178,6 +178,7 @@ class _ItemV2 extends StatelessWidget {
             children: [
               Expanded(
                 child: ClipPath(
+                  clipper: _HoleClipper(isLeft: false),
                   child: Container(
                     padding: EdgeInsets.symmetric(vertical: 14, horizontal: 12),
                     color: Palette.white,
@@ -224,33 +225,41 @@ class _ItemV2 extends StatelessWidget {
                   ),
                 ),
               ),
-              CustomPaint(
-                foregroundPainter: _DashedLinePainter(
-                  dashWidth: 4,
-                  dashSpace: 4,
-                  startY: 0,
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: 5),
+                child: CustomPaint(
+                  foregroundPainter: _DashedLinePainter(
+                    dashWidth: 4,
+                    dashSpace: 4,
+                    startY: 0,
+                  ),
+                  child: Container(width: 1),
                 ),
-                child: Container(width: 8),
               ),
-              Container(
-                color: Palette.primaryLight,
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      context.t.create.capacity.fields.max_capacity.item(
-                        n: pot.current,
+              ClipPath(
+                clipper: _HoleClipper(isLeft: true),
+                child: Container(
+                  color: Palette.primaryLight,
+                  padding: EdgeInsets.symmetric(horizontal: 12),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        context.t.create.capacity.fields.max_capacity.item(
+                          n: pot.current,
+                        ),
+                        style: TextStyles.title3.copyWith(
+                          color: Palette.primary,
+                        ),
                       ),
-                      style: TextStyles.title3.copyWith(color: Palette.primary),
-                    ),
-                    Text(
-                      '/${context.t.create.capacity.fields.max_capacity.item(n: pot.total)}',
-                      style: TextStyles.caption.copyWith(
-                        color: Palette.textGrey,
+                      Text(
+                        '/${context.t.create.capacity.fields.max_capacity.item(n: pot.total)}',
+                        style: TextStyles.caption.copyWith(
+                          color: Palette.textGrey,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],
@@ -299,6 +308,40 @@ class _DashedLinePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_DashedLinePainter oldDelegate) => false;
+}
+
+class _HoleClipper extends CustomClipper<Path> {
+  final bool isLeft;
+  final double radius = 5;
+  final double gap = 1;
+  _HoleClipper({required this.isLeft});
+  @override
+  Path getClip(Size size) {
+    return Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect(Offset.zero & size)
+      ..addOval(
+        Rect.fromCenter(
+          center: isLeft
+              ? size.topLeft(Offset(-gap / 2, 0))
+              : size.topRight(Offset(gap / 2, 0)),
+          width: radius * 2,
+          height: radius * 2,
+        ),
+      )
+      ..addOval(
+        Rect.fromCenter(
+          center: isLeft
+              ? size.bottomLeft(Offset(-gap / 2, 0))
+              : size.bottomRight(Offset(gap / 2, 0)),
+          width: radius * 2,
+          height: radius * 2,
+        ),
+      );
+  }
+
+  @override
+  bool shouldReclip(_HoleClipper oldClipper) => true;
 }
 
 extension on PotSummaryEntity {

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -291,7 +291,7 @@ class _DashedLinePainter extends CustomPainter {
       Paint()..color = Palette.primaryLight,
     );
     final paint = Paint()
-      ..color = Colors.grey
+      ..color = Palette.borderGrey
       ..strokeWidth = 1
       ..strokeCap = StrokeCap.round;
     canvas.save();

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -254,20 +254,24 @@ class _ItemV2 extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(height: 4),
-                      Text.rich(
-                        TextSpan(
-                          children: [
-                            TextSpan(
-                              text: pot.current.toString(),
-                              style: TextStyles.title4.copyWith(
-                                color: Palette.primary,
+                      SizedBox(
+                        width: 50,
+                        child: Text.rich(
+                          textAlign: TextAlign.center,
+                          TextSpan(
+                            children: [
+                              TextSpan(
+                                text: pot.current.toString(),
+                                style: TextStyles.title4.copyWith(
+                                  color: Palette.primary,
+                                ),
                               ),
-                            ),
-                            TextSpan(text: '/${pot.total}'),
-                          ],
-                        ),
-                        style: TextStyles.body.copyWith(
-                          color: Palette.textGrey,
+                              TextSpan(text: '/${pot.total}'),
+                            ],
+                          ),
+                          style: TextStyles.body.copyWith(
+                            color: Palette.textGrey,
+                          ),
                         ),
                       ),
                     ],

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/date_time.dart';
@@ -22,7 +23,7 @@ class PotListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final version = 2;
+    final version = kDebugMode ? 2 : 1;
     return PotPressable(
       onTap: pot.disabled
           ? null

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -208,16 +208,17 @@ class _ItemV2 extends StatelessWidget {
                               TextSpan(
                                 text: DateFormat.Hm().format(pot.endsAt),
                               ),
-                              TextSpan(
-                                text: 'D+1',
-                                style: TextStyles.description.copyWith(
-                                  fontSize: 12,
+                              if (!pot.startsAt.isSameDay(pot.endsAt))
+                                TextSpan(
+                                  text: 'D+1',
+                                  style: TextStyles.description.copyWith(
+                                    fontSize: 12,
 
-                                  color: pot.disabled
-                                      ? Palette.grey
-                                      : Palette.textGrey,
+                                    color: pot.disabled
+                                        ? Palette.grey
+                                        : Palette.textGrey,
+                                  ),
                                 ),
-                              ),
                             ],
                           ),
                           style: TextStyles.title3.copyWith(

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -248,16 +248,25 @@ class _ItemV2 extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        context.t.create.capacity.fields.max_capacity.item(
-                          n: pot.current,
-                        ),
-                        style: TextStyles.title3.copyWith(
-                          color: Palette.primary,
+                        context.t.create.capacity.fields.max_capacity.label,
+                        style: TextStyles.caption2.copyWith(
+                          color: Palette.textGrey,
                         ),
                       ),
-                      Text(
-                        '/${context.t.create.capacity.fields.max_capacity.item(n: pot.total)}',
-                        style: TextStyles.caption.copyWith(
+                      const SizedBox(height: 4),
+                      Text.rich(
+                        TextSpan(
+                          children: [
+                            TextSpan(
+                              text: pot.current.toString(),
+                              style: TextStyles.title4.copyWith(
+                                color: Palette.primary,
+                              ),
+                            ),
+                            TextSpan(text: '/${pot.total}'),
+                          ],
+                        ),
+                        style: TextStyles.body.copyWith(
                           color: Palette.textGrey,
                         ),
                       ),

--- a/lib/app/modules/list/presentation/widgets/pot_list_item.dart
+++ b/lib/app/modules/list/presentation/widgets/pot_list_item.dart
@@ -215,6 +215,10 @@ class _ItemV2 extends StatelessWidget {
                   ),
                 ),
               ),
+              CustomPaint(
+                foregroundPainter: _DashedLinePainter(),
+                child: Container(width: 8),
+              ),
               Container(
                 color: Palette.primaryLight,
                 padding: EdgeInsets.symmetric(horizontal: 12),
@@ -247,17 +251,24 @@ class _ItemV2 extends StatelessWidget {
 class _DashedLinePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    double dashWidth = 8, dashSpace = 8, startY = 0;
+    double dashWidth = 4, dashSpace = 4, startY = 0;
+    canvas.drawRect(
+      Offset.zero & Size(size.width / 2, size.height),
+      Paint()..color = Palette.white,
+    );
+    canvas.drawRect(
+      Offset(size.width / 2, 0) & Size(size.width / 2, size.height),
+      Paint()..color = Palette.primaryLight,
+    );
     final paint = Paint()
       ..color = Colors.grey
       ..strokeWidth = 1
       ..strokeCap = StrokeCap.round;
-    canvas.clipRect(Offset.zero & size);
     canvas.save();
     while (startY < size.height) {
       canvas.drawLine(
-        Offset(0, startY),
-        Offset(0, min(startY + dashWidth, size.height)),
+        Offset(size.width / 2, startY),
+        Offset(size.width / 2, min(startY + dashWidth, size.height)),
         paint,
       );
       startY += dashWidth + dashSpace;

--- a/lib/app/values/text_styles.dart
+++ b/lib/app/values/text_styles.dart
@@ -44,4 +44,10 @@ abstract class TextStyles {
     height: 1,
     fontWeight: FontWeight.w400,
   );
+
+  static final caption2 = TextStyle(
+    fontSize: 12,
+    height: 1,
+    fontWeight: FontWeight.w400,
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -692,18 +692,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_web_auth_2
-      sha256: "3c14babeaa066c371f3a743f204dd0d348b7d42ffa6fae7a9847a521aff33696"
+      sha256: fb584c8a285722eb98363240f0aac608cc546f8d28080cdf05edfad27ace2af0
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0-alpha.7"
   flutter_web_auth_2_platform_interface:
     dependency: transitive
     description:
       name: flutter_web_auth_2_platform_interface
-      sha256: c63a472c8070998e4e422f6b34a17070e60782ac442107c70000dd1bed645f4d
+      sha256: e25eb45c50b3eef5a80d0ae73c7ecf82e291c152387da8d2008bfd607ba43087
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0-alpha.4"
   flutter_web_plugins:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
<img width="514" height="1762" alt="CleanShot 2025-11-13 at 14 47 10@2x" src="https://github.com/user-attachments/assets/fb3b1f9d-99bd-48c0-8cd6-0161eb086fac" />

위와 같이 painter, clipper를 사용하고 있습니다

Divider가 width 1px을 잡고 있기 때문에, Clipper가 우측과 좌측으로 0.5px 씩 이동한 지점을 원점으로 가져야 합니다.
또한 Divider가 1px을 잡을 때 배경이 뚫리는 형태가 되기 때문에 좌측배경(흰색)과 우측배경(primaryLight)를 칠해줍니다


- **feat: new item layout**
- **feat: list new layout**
- **fix: first date changed indicator**
- **feat: banner padding**
- **chore(deps): update Podfile.lock**
- **feat: dashed line**
- **refactor: enhance dashed line painter and update item layout**
- **feat: hole clipping**
- **fix: change color**
- **refactor: extract constants for line width and radius in PotListItem**
- **feat: change text for capacity**
- **feat: width for capacity number**
- **feat: show new design only in debug mode**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팟 생성 폼의 최대 정원 필드에 "정원" 레이블 추가
  * 텍스트 스타일에 새로운 캡션 스타일(caption2) 추가

* **개선 사항**
  * 목록 보기에 일자 헤더(날짜 구분선) 추가로 가독성 향상
  * 팟 목록 항목의 시각적 레이아웃 개선 및 버전별 렌더링으로 더 풍부한 표출
  * 채팅 목록이 배너 표시 여부에 따라 레이아웃·패딩을 적절히 조정하도록 개선
* **기타**
  * 팟 항목의 선택/탭 동작이 비활성 상태에 맞춰 제어되도록 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->