### PR TITLE
fix: add close icon to toast notifications for better user experience

### DIFF
--- a/lib/app/modules/common/presentation/extensions/toast.dart
+++ b/lib/app/modules/common/presentation/extensions/toast.dart
@@ -4,6 +4,6 @@ extension BuildContextX on BuildContext {
   void showToast(String message) {
     ScaffoldMessenger.of(this)
       ..clearSnackBars()
-      ..showSnackBar(SnackBar(content: Text(message)));
+      ..showSnackBar(SnackBar(content: Text(message), showCloseIcon: true));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항
* **사용자 인터페이스 개선**
  * 토스트 알림에 닫기 버튼이 추가되어 알림을 더 쉽게 닫을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->