### PR TITLE
fix: prevent setting departure time in the past

### DIFF
--- a/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
@@ -85,12 +85,6 @@ class SetDepartureTimeButton extends StatefulWidget {
     l.c('confirmDepartureTime', from: 'departureTimeConfirm');
     if (!context.mounted) return;
 
-    if (date.isBefore(DateTime.now())) {
-      context.showToast("Cannot set departure time in the past.");
-      // TODO: i18n
-      return;
-    }
-
     context.read<PotActionBloc>().add(
       PotActionEvent.setDepartureTime(pot, date),
     );

--- a/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
@@ -77,6 +77,13 @@ class SetDepartureTimeButton extends StatefulWidget {
     if (result2 != OkCancelResult.ok) return;
     l.c('confirmDepartureTime', from: 'departureTimeConfirm');
     if (!context.mounted) return;
+
+    if (date.isBefore(DateTime.now())) {
+      context.showToast("Cannot set departure time in the past.");
+      // TODO: i18n
+      return;
+    }
+
     context.read<PotActionBloc>().add(
       PotActionEvent.setDepartureTime(pot, date),
     );

--- a/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
@@ -10,6 +10,7 @@ import 'package:pot_g/app/modules/chat/presentation/extensions/pot_user_extensio
 import 'package:pot_g/app/modules/chat/presentation/widgets/tooltip_overlay.dart';
 import 'package:pot_g/app/modules/common/domain/enums/tooltip_type.dart';
 import 'package:pot_g/app/modules/common/presentation/bloc/tooltip_cubit.dart';
+import 'package:pot_g/app/modules/common/presentation/extensions/date_time.dart';
 import 'package:pot_g/app/modules/common/presentation/extensions/toast.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/common/presentation/widgets/general_dialog.dart';
@@ -57,10 +58,7 @@ class SetDepartureTimeButton extends StatefulWidget {
         height: 180,
         child: CupertinoDatePicker(
           initialDateTime: date,
-          minimumDate:
-              (pot.startsAt.year == DateTime.now().year &&
-                  pot.startsAt.month == DateTime.now().month &&
-                  pot.startsAt.day == DateTime.now().day)
+          minimumDate: pot.startsAt.isSameDay(DateTime.now())
               ? DateTime.now()
               : null,
           onDateTimeChanged: (value) => date = value,

--- a/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
+++ b/lib/app/modules/chat/presentation/widgets/set_departure_time_button.dart
@@ -49,7 +49,7 @@ class SetDepartureTimeButton extends StatefulWidget {
       return;
     }
     l.v('setDepartureTime');
-    DateTime date = DateTime.now();
+    DateTime date = DateTime.now().add(const Duration(minutes: 1));
     final result = await showGeneralOkCancelAdaptiveDialog(
       context: context,
       title: context.t.chat_room.set_departure_time.clock.title,
@@ -57,12 +57,19 @@ class SetDepartureTimeButton extends StatefulWidget {
         height: 180,
         child: CupertinoDatePicker(
           initialDateTime: date,
+          minimumDate:
+              (pot.startsAt.year == DateTime.now().year &&
+                  pot.startsAt.month == DateTime.now().month &&
+                  pot.startsAt.day == DateTime.now().day)
+              ? DateTime.now()
+              : null,
           onDateTimeChanged: (value) => date = value,
           mode: CupertinoDatePickerMode.time,
         ),
       ),
       okLabel: context.t.common.confirm,
     );
+
     if (result != OkCancelResult.ok) return;
     if (!context.mounted) return;
     l.v('departureTimeConfirm', from: 'setDepartureTime');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1430,10 +1430,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 출발 시간을 과거로 설정하려 할 때 경고 표시 및 설정 차단 동작을 유지하여 잘못된 입력 방지.
  * 확인 대화상자 흐름은 기존과 동일하게 유지.

* **개선**
  * 출발 시간 선택 시 초기값을 현재가 아닌 1분 후로 설정해 실수 입력 감소.
  * 날짜/시간 선택기에서 오늘 선택 시 최소 허용값을 현재 시각으로 제한.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->