### PR TITLE
feat: remove badge when open app on iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -12,6 +12,7 @@ import UIKit
   }
 
   override func applicationDidBecomeActive(_ application: UIApplication) {
-    application.applicationIconBadgeNumber = 0;
+    super.applicationDidBecomeActive(application)
+    application.applicationIconBadgeNumber = 0
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,4 +10,8 @@ import UIKit
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  override func applicationDidBecomeActive(_ application: UIApplication) {
+    application.applicationIconBadgeNumber = 0;
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 앱이 활성화될 때 알림 배지 번호가 자동으로 0으로 초기화됩니다.
  * 결과: 홈 화면의 앱 아이콘에 남아있던 배지 알림이 앱 재진입 시 자동으로 제거되어 알림 상태가 명확해집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->