### PR TITLE
fix: prevent leaving archived pots

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -324,6 +324,9 @@
             "title": "Leave the pot?",
             "description": "You can leave freely before the departure time is confirmed. Do you want to leave?"
           },
+          "archived": {
+            "title": "Already archived pot"
+          },
           "departure_confirmed": "After the departure time is confirmed, you cannot leave.",
           "error": {
             "after_departure_confirmed": "After the departure time is confirmed, you cannot leave.",

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -321,6 +321,9 @@
             "title": "퇴장하시겠습니까?",
             "description": "출발 시간 확정 이전에는\n자유로운 퇴장이 가능합니다\n퇴장하시겠습니까?"
           },
+           "archived": {
+            "title": "이미 해산된 팟입니다"
+          },
           "departure_confirmed": "출발 시간을 확정한 이후에는 퇴장이 불가능합니다",
           "error": {
             "after_departure_confirmed": "출발 시간을 확정한 이후에는 퇴장이 불가능합니다",

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -93,6 +93,16 @@ class ChatRoomDrawer extends StatelessWidget {
       return;
     }
 
+    if (pot.isArchived) {
+      showOkAlertDialog(
+        context: context,
+        title: context.t.chat_room.drawer.actions.leave.archived.title,
+        message:
+            context.t.chat_room.drawer.actions.leave.error.pot_already_closed,
+      );
+      return;
+    }
+
     final result = await showOkCancelAlertDialog(
       context: context,
       title: context.t.chat_room.drawer.actions.leave.confirm.title,

--- a/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
+++ b/lib/app/modules/chat/presentation/widgets/chat_room_drawer.dart
@@ -84,21 +84,21 @@ class ChatRoomDrawer extends StatelessWidget {
 
   Future<void> _leave(BuildContext context) async {
     L.c('leave', properties: {'potId': pot.id, 'potName': pot.name});
-    if (pot.departureTime != null) {
-      showOkAlertDialog(
-        context: context,
-        title: context.t.chat_room.drawer.members.departure_confirmed,
-        message: context.t.chat_room.drawer.actions.leave.departure_confirmed,
-      );
-      return;
-    }
-
     if (pot.isArchived) {
       showOkAlertDialog(
         context: context,
         title: context.t.chat_room.drawer.actions.leave.archived.title,
         message:
             context.t.chat_room.drawer.actions.leave.error.pot_already_closed,
+      );
+      return;
+    }
+
+    if (pot.departureTime != null) {
+      showOkAlertDialog(
+        context: context,
+        title: context.t.chat_room.drawer.members.departure_confirmed,
+        message: context.t.chat_room.drawer.actions.leave.departure_confirmed,
       );
       return;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1430,10 +1430,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 해산(아카이브)된 팟에서 나가기를 시도할 때, 관련 경고 대화상이 표시되고 기존 나가기 흐름이 중단되도록 개선되었습니다.

- **다국어 지원**
  - 해산된 팟 관련 알림 문구에 대한 한국어 및 영어 번역 항목이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->