### PR TITLE
fix: app not opening on notification click

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,10 @@
           android:host="dev.pot-g.gistory.me" />
         <data android:scheme="pot-g" android:host="pot-g.gistory.me" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="FLUTTER_NOTIFICATION_CLICK"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
     </activity>
 
     <activity


### PR DESCRIPTION
AndroidManifest.xml 파일 내에 알림을 클릭했을 때 들어올 수 있도록 하는 intent 필터가 없어서 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 클릭 이벤트 처리 기능이 추가되었습니다. 이제 알림을 탭할 때 앱이 올바르게 응답합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->