### PR TITLE
chore(ci) : add build version in slack message

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -15,7 +15,98 @@ platform :android do
 
   desc "Deploy a new version to the Google Play"
   lane :internal do
+    version_codes = google_play_track_version_codes(track: "internal")default_platform(:android)
+
+platform :android do
+  desc "Test build"
+  lane :test do
+    UI.message("Building for testing")
+    aabPath = "../../build/app/outputs/bundle/debug/app-debug.aab"
+    FileUtils.remove_dir(aabPath) if File.directory?(aabPath)
+
+    sh("flutter", "build", "appbundle", "--debug")
+    unless File.exist?(aabPath)
+      UI.user_error!("Build failed")
+    end
+  end
+
+  desc "Deploy a new version to the Google Play"
+  lane :internal do
     version_codes = google_play_track_version_codes(track: "internal")
+    pubspec = YAML.load_file("../../pubspec.yaml")
+    build_version = pubspec["version"]
+    build_number = version_codes.max + 1
+    version_string = "#{build_version} (#{build_number})"
+    UI.message("Building #{pubspec["name"]} #{version_string}")
+
+    android_app_id = File.open("../../lib/firebase_options.dart").read().match(/appId: '(.*android.*)'/)[1]
+    UI.message("Android App ID: #{android_app_id}")
+    debug_info_path = "build/app/outputs/symbols"
+
+    sh(
+      "flutter", "build", "appbundle",
+      "--obfuscate",
+      "--split-debug-info=#{debug_info_path}",
+      "--release",
+      "--build-number=#{build_number}",
+    )
+
+    begin
+      sh("firebase", "crashlytics:symbols:upload", "--app=#{android_app_id}", "../../#{debug_info_path}")
+    rescue => e
+      UI.message("Ignoring error during Crashlytics symbols upload: #{e.message}")
+    end
+
+    symbols_path = File.expand_path("../../build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")
+    Dir.chdir(symbols_path) do
+      sh("zip", "-r", "native_symbol.zip", ".")
+    end
+
+    upload_to_play_store(
+      aab: "../build/app/outputs/bundle/release/app-release.aab",
+      track: "internal",
+      version_name: version_string,
+      mapping_paths: [
+        "../build/app/outputs/mapping/release/mapping.txt",
+        "#{symbols_path}/native_symbol.zip",
+      ],
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+    begin
+      internal_app_url = upload_to_play_store_internal_app_sharing(
+        aab: "../build/app/outputs/bundle/release/app-release.aab",
+      )
+    rescue => e
+      UI.message("Error during internal app sharing upload: #{e.message}")
+      internal_app_url = "Failed"
+    end
+    
+    slack(
+      payload: {
+        "Build Date" => Time.now.to_s,
+        "Build Number" => build_number,
+        "Build Version" => build_version,
+        "Internal App" => internal_app_url == "Failed" ? "Failed" : "<#{internal_app_url}>",
+      }
+    ) if ENV['CI']
+  end
+
+  lane :production do
+    upload_to_play_store(
+      track: "internal",
+      track_promote_to: "production",
+      skip_upload_changelogs: true,
+    )
+    slack(
+      payload: {
+        "Promoted At" => Time.now.to_s,
+      }
+    ) if ENV['CI']
+  end
+end
+
     build_number = version_codes.max + 1
     pubspec = YAML.load_file("../../pubspec.yaml")
     build_version = pubspec['version']

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -18,6 +18,7 @@ platform :android do
     version_codes = google_play_track_version_codes(track: "internal")
     build_number = version_codes.max + 1
     pubspec = YAML.load_file("../../pubspec.yaml")
+    build_version = pubspec['version']
     version_string = "#{pubspec["version"]} (#{build_number})"
     UI.message("Building #{pubspec["name"]} #{version_string}")
 
@@ -69,6 +70,7 @@ platform :android do
       payload: {
         "Build Date" => Time.now.to_s,
         "Build Number" => build_number,
+        "Build Version" => build_version,
         "Internal App" => internal_app_url == "Failed" ? "Failed" : "<#{internal_app_url}>",
       }
     ) if ENV['CI']

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -15,102 +15,11 @@ platform :android do
 
   desc "Deploy a new version to the Google Play"
   lane :internal do
-    version_codes = google_play_track_version_codes(track: "internal")default_platform(:android)
-
-platform :android do
-  desc "Test build"
-  lane :test do
-    UI.message("Building for testing")
-    aabPath = "../../build/app/outputs/bundle/debug/app-debug.aab"
-    FileUtils.remove_dir(aabPath) if File.directory?(aabPath)
-
-    sh("flutter", "build", "appbundle", "--debug")
-    unless File.exist?(aabPath)
-      UI.user_error!("Build failed")
-    end
-  end
-
-  desc "Deploy a new version to the Google Play"
-  lane :internal do
     version_codes = google_play_track_version_codes(track: "internal")
     pubspec = YAML.load_file("../../pubspec.yaml")
     build_version = pubspec["version"]
     build_number = version_codes.max + 1
     version_string = "#{build_version} (#{build_number})"
-    UI.message("Building #{pubspec["name"]} #{version_string}")
-
-    android_app_id = File.open("../../lib/firebase_options.dart").read().match(/appId: '(.*android.*)'/)[1]
-    UI.message("Android App ID: #{android_app_id}")
-    debug_info_path = "build/app/outputs/symbols"
-
-    sh(
-      "flutter", "build", "appbundle",
-      "--obfuscate",
-      "--split-debug-info=#{debug_info_path}",
-      "--release",
-      "--build-number=#{build_number}",
-    )
-
-    begin
-      sh("firebase", "crashlytics:symbols:upload", "--app=#{android_app_id}", "../../#{debug_info_path}")
-    rescue => e
-      UI.message("Ignoring error during Crashlytics symbols upload: #{e.message}")
-    end
-
-    symbols_path = File.expand_path("../../build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")
-    Dir.chdir(symbols_path) do
-      sh("zip", "-r", "native_symbol.zip", ".")
-    end
-
-    upload_to_play_store(
-      aab: "../build/app/outputs/bundle/release/app-release.aab",
-      track: "internal",
-      version_name: version_string,
-      mapping_paths: [
-        "../build/app/outputs/mapping/release/mapping.txt",
-        "#{symbols_path}/native_symbol.zip",
-      ],
-      skip_upload_metadata: true,
-      skip_upload_images: true,
-      skip_upload_screenshots: true,
-    )
-    begin
-      internal_app_url = upload_to_play_store_internal_app_sharing(
-        aab: "../build/app/outputs/bundle/release/app-release.aab",
-      )
-    rescue => e
-      UI.message("Error during internal app sharing upload: #{e.message}")
-      internal_app_url = "Failed"
-    end
-    
-    slack(
-      payload: {
-        "Build Date" => Time.now.to_s,
-        "Build Number" => build_number,
-        "Build Version" => build_version,
-        "Internal App" => internal_app_url == "Failed" ? "Failed" : "<#{internal_app_url}>",
-      }
-    ) if ENV['CI']
-  end
-
-  lane :production do
-    upload_to_play_store(
-      track: "internal",
-      track_promote_to: "production",
-      skip_upload_changelogs: true,
-    )
-    slack(
-      payload: {
-        "Promoted At" => Time.now.to_s,
-      }
-    ) if ENV['CI']
-  end
-end
-
-    build_number = version_codes.max + 1
-    pubspec = YAML.load_file("../../pubspec.yaml")
-    build_version = pubspec['version']
-    version_string = "#{pubspec["version"]} (#{build_number})"
     UI.message("Building #{pubspec["name"]} #{version_string}")
 
     android_app_id = File.open("../../lib/firebase_options.dart").read().match(/appId: '(.*android.*)'/)[1]

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -23,8 +23,9 @@ platform :ios do
     app_store_connect_api_key(duration: 1200) if ENV['CI']
 
     pubspec = YAML.load_file("../../pubspec.yaml")
+    build_version = pubspec["version"]
     build_number = latest_testflight_build_number + 1
-    version_string = "#{pubspec["version"]} (#{build_number})"
+    version_string = "#{build_version} (#{build_number})"
     UI.message("Building #{pubspec["name"]} #{version_string}")
 
     exportOptionsFilePath = "#{Tempfile.new('exportOptions').path}.plist"
@@ -47,6 +48,7 @@ platform :ios do
     slack(
       payload: {
         "Build Date" => Time.now.to_s,
+        "Build Version" => build_version,
         "Build Number" => build_number,
       }
     ) if ENV['CI']


### PR DESCRIPTION
슬랙(#taxi-cicd)에 뜨는 알림에 build_version을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 빌드 자동화에 테스트/내부/프로덕션 배포 단계를 추가하고, 빌드 버전 정보를 수집해 모든 배포 흐름과 알림에 일관되게 포함하도록 개선했습니다.
  * 내부 배포 시 심볼 업로드 시도, 내부 앱 공유 링크 생성 시도 및 매핑(버전) 처리 자동화와 실패 허용 처리를 추가했습니다.
  * CI 전용으로 확장된 Slack 알림에 빌드 날짜·번호·버전 및 내부 앱 URL/프로모션 시각을 포함하도록 업데이트했습니다.

**참고**: 변경은 배포·알림 흐름 개선에 중점되어 있어 최종 사용자에게 직접적인 영향은 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->