### PR TITLE
fix: update promotional banner URL

### DIFF
--- a/lib/app/modules/list/presentation/pages/list_page.dart
+++ b/lib/app/modules/list/presentation/pages/list_page.dart
@@ -33,7 +33,7 @@ final _listBannerEntries = [
   BannerEntry(
     asset: Assets.images.bannerInfoteam,
     onTap: () => launchUrlString(
-      'https://infoteam-rulrudino.notion.site/2fb365ea27df8061ae1cdd7067d31580?pvs=105',
+      'https://www.notion.so/infoteam-rulrudino/2026-309365ea27df80488137d0680fd51686?source=copy_link',
     ),
   ),
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Infoteam 배너의 링크를 새로운 Notion 페이지로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->