### PR TITLE
feat: remove infoteam recruiting banner

### DIFF
--- a/lib/app/modules/list/presentation/pages/list_page.dart
+++ b/lib/app/modules/list/presentation/pages/list_page.dart
@@ -30,12 +30,6 @@ final _listBannerEntries = [
     onTap: () =>
         launchUrlString('https://ziggle.gistory.me/app?redirect=/home'),
   ),
-  BannerEntry(
-    asset: Assets.images.bannerInfoteam,
-    onTap: () => launchUrlString(
-      'https://www.notion.so/infoteam-rulrudino/2026-309365ea27df80488137d0680fd51686?source=copy_link',
-    ),
-  ),
 ];
 
 @RoutePage()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pot_g
 description: "A new Flutter project."
 publish_to: "none"
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 배너 캐러셀에서 항목 하나를 제거해 더 간결한 인터페이스를 제공합니다.
* **Chores**
  * 앱 버전이 1.1.0에서 1.1.1로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->