### PR TITLE
fix: replace raw error messages with i18n strings and error ids

### DIFF
--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -484,6 +484,9 @@
       "title": "Update Required",
       "message": "Please update to the latest version to continue.\n\nCurrent version: $currentVersion\nLatest version: $latestVersion",
       "button": "Update"
+    },
+    "error": {
+      "title": "App version error"
     }
   },
   "consent": {

--- a/assets/i18n/en.i18n.json
+++ b/assets/i18n/en.i18n.json
@@ -219,6 +219,10 @@
         "resend": "Resend"
       }
     },
+    "load_error": {
+      "network_error": "Network error occurred.",
+      "unknown": "Unknown error occurred."
+    },
     "system_messages": {
       "created": {
         "description": "$user created the pot."

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -216,6 +216,10 @@
         "resend": "재전송"
       }
     },
+    "load_error": {
+      "network_error": "네트워크 오류가 발생했습니다",
+      "unknown": "알 수 없는 오류가 발생했습니다"
+    },
     "system_messages": {
       "created": {
         "description": "$user 님이 팟을 생성하셨습니다"
@@ -330,7 +334,7 @@
             "title": "퇴장하시겠습니까?",
             "description": "출발 시간 확정 이전에는\n자유로운 퇴장이 가능합니다\n퇴장하시겠습니까?"
           },
-           "archived": {
+          "archived": {
             "title": "이미 해산된 팟입니다"
           },
           "departure_confirmed": "출발 시간을 확정한 이후에는 퇴장이 불가능합니다",

--- a/assets/i18n/ko.i18n.json
+++ b/assets/i18n/ko.i18n.json
@@ -481,6 +481,9 @@
       "title": "업데이트 필요",
       "message": "팟쥐를 계속 사용하기 위해서 최신 버전으로 업데이트해주세요.\n현재 버전: $currentVersion\n최신 버전: $latestVersion",
       "button": "업데이트"
+    },
+    "error": {
+      "title": "앱 버전 오류"
     }
   },
   "consent": {

--- a/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
@@ -26,10 +26,13 @@ class WebsocketPotInfoRepository implements PotInfoRepository {
   Stream<PotInfoEntity> getPotInfoStream(PotIdEntity pot) async* {
     try {
       yield await _api.getPotInfo(pot.id);
-    } on DioException catch (e) {
-      throw PotInfoException.networkError(e.message ?? e.error.toString());
-    } catch (e) {
-      throw PotInfoException.unknown(e);
+    } on DioException catch (e, stackTrace) {
+      Error.throwWithStackTrace(
+        PotInfoException.networkError(e.message ?? e.error.toString()),
+        stackTrace,
+      );
+    } catch (e, stackTrace) {
+      Error.throwWithStackTrace(PotInfoException.unknown(e), stackTrace);
     }
 
     yield* _socket
@@ -49,12 +52,18 @@ class WebsocketPotInfoRepository implements PotInfoRepository {
         .asyncMap((e) async {
           try {
             return await _api.getPotInfo(pot.id);
-          } on DioException catch (e) {
-            throw PotInfoException.networkError(
-              e.message ?? e.error.toString(),
+          } on DioException catch (e, stackTrace) {
+            Error.throwWithStackTrace(
+              PotInfoException.networkError(
+                e.message ?? e.error.toString(),
+              ),
+              stackTrace,
             );
-          } catch (e) {
-            throw PotInfoException.unknown(e);
+          } catch (e, stackTrace) {
+            Error.throwWithStackTrace(
+              PotInfoException.unknown(e),
+              stackTrace,
+            );
           }
         });
   }

--- a/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
+++ b/lib/app/modules/chat/data/repositories/websocket_pot_info_repository.dart
@@ -1,6 +1,8 @@
+import 'package:dio/dio.dart' show DioException;
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/data/data_sources/remote/chat_pot_api.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/pot_info_exception.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_info_repository.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
 import 'package:pot_g/app/modules/socket/data/data_sources/websocket.dart';
@@ -22,7 +24,14 @@ class WebsocketPotInfoRepository implements PotInfoRepository {
 
   @override
   Stream<PotInfoEntity> getPotInfoStream(PotIdEntity pot) async* {
-    yield await _api.getPotInfo(pot.id);
+    try {
+      yield await _api.getPotInfo(pot.id);
+    } on DioException catch (e) {
+      throw PotInfoException.networkError(e.message ?? e.error.toString());
+    } catch (e) {
+      throw PotInfoException.unknown(e);
+    }
+
     yield* _socket
         .createStreamFor<PotEventModel>()
         .map((e) => e.body)
@@ -37,6 +46,16 @@ class WebsocketPotInfoRepository implements PotInfoRepository {
               p is PotEventModel<ArchiveV1Event>,
         )
         .where((e) => e.potPk == pot.id)
-        .asyncMap((e) => _api.getPotInfo(pot.id));
+        .asyncMap((e) async {
+          try {
+            return await _api.getPotInfo(pot.id);
+          } on DioException catch (e) {
+            throw PotInfoException.networkError(
+              e.message ?? e.error.toString(),
+            );
+          } catch (e) {
+            throw PotInfoException.unknown(e);
+          }
+        });
   }
 }

--- a/lib/app/modules/chat/domain/exceptions/pot_info_exception.dart
+++ b/lib/app/modules/chat/domain/exceptions/pot_info_exception.dart
@@ -1,0 +1,24 @@
+sealed class PotInfoException implements Exception {
+  const PotInfoException();
+
+  const factory PotInfoException.networkError(String error) =
+      PotInfoNetworkErrorException;
+  const factory PotInfoException.unknown(Object error) =
+      PotInfoUnknownException;
+}
+
+class PotInfoNetworkErrorException extends PotInfoException {
+  final String error;
+  const PotInfoNetworkErrorException(this.error);
+
+  @override
+  String toString() => 'PotInfoException.NetworkErrorException(error: $error)';
+}
+
+class PotInfoUnknownException extends PotInfoException {
+  final Object error;
+  const PotInfoUnknownException(this.error);
+
+  @override
+  String toString() => 'PotInfoException.UnknownException(error: $error)';
+}

--- a/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/chat_bloc.dart
@@ -55,8 +55,8 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
       );
       return stream;
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(state.copyWith(isLoading: false, error: e.toString()));
+      final errorId = L.e(e, stackTrace);
+      emit(state.copyWith(isLoading: false, error: errorId));
     } finally {
       _mutex.release();
     }
@@ -79,13 +79,13 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         ),
       );
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
+      final errorId = L.e(e, stackTrace);
       emit(
         state.copyWith(
           isLoading: false,
-          error: e.toString(),
+          error: errorId,
           pendingChats: state.pendingChats
-              .map((c) => c.id == chat.id ? chat.withError(e.toString()) : c)
+              .map((c) => c.id == chat.id ? chat.withError(errorId) : c)
               .toList(),
         ),
       );
@@ -110,12 +110,12 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         ),
       );
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
+      final errorId = L.e(e, stackTrace);
       emit(
         state.copyWith(
-          error: e.toString(),
+          error: errorId,
           pendingChats: state.pendingChats
-              .map((c) => c.id == chat.id ? chat.withError(e.toString()) : c)
+              .map((c) => c.id == chat.id ? chat.withError(errorId) : c)
               .toList(),
         ),
       );

--- a/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
+++ b/lib/app/modules/chat/presentation/bloc/pot_info_bloc.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:pot_g/app/modules/chat/domain/entities/pot_info_entity.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/pot_info_exception.dart';
 import 'package:pot_g/app/modules/chat/domain/repositories/pot_info_repository.dart';
 import 'package:pot_g/app/modules/common/presentation/utils/log.dart';
 import 'package:pot_g/app/modules/core/domain/entities/pot_id_entity.dart';
@@ -22,8 +23,11 @@ class PotInfoBloc extends Bloc<PotInfoEvent, PotInfoState> {
       _repository.getPotInfoStream(event.pot),
       onData: (pot) => PotInfoState.loaded(pot),
       onError: (error, stackTrace) {
-        L.e(error, stackTrace);
-        return PotInfoState.error(error.toString());
+        final errorId = L.e(error, stackTrace);
+        final exception = error is PotInfoException
+            ? error
+            : PotInfoException.unknown(error);
+        return PotInfoState.error(exception, errorId);
       },
     );
   }
@@ -39,14 +43,15 @@ sealed class PotInfoState with _$PotInfoState {
   const PotInfoState._();
   const factory PotInfoState.loading() = _Loading;
   const factory PotInfoState.loaded(PotInfoEntity pot) = _Loaded;
-  const factory PotInfoState.error(String message) = _Error;
+  const factory PotInfoState.error(PotInfoException err, String errorId) =
+      _Error;
 
   PotInfoEntity? get pot => switch (this) {
     _Loaded(:final pot) => pot,
     _ => null,
   };
-  String? get error => switch (this) {
-    _Error(:final message) => message,
+  ({PotInfoException err, String errorId})? get error => switch (this) {
+    _Error(:final err, :final errorId) => (err: err, errorId: errorId),
     _ => null,
   };
 }

--- a/lib/app/modules/chat/presentation/extensions/pot_info_exception_extension.dart
+++ b/lib/app/modules/chat/presentation/extensions/pot_info_exception_extension.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+import 'package:pot_g/app/modules/chat/domain/exceptions/pot_info_exception.dart';
+import 'package:pot_g/gen/strings.g.dart';
+
+extension PotInfoExceptionX on PotInfoException {
+  String getErrorMessage(BuildContext context) {
+    final errors = context.t.chat_room.load_error;
+    return switch (this) {
+      PotInfoNetworkErrorException() => errors.network_error,
+      PotInfoUnknownException() => errors.unknown,
+    };
+  }
+}

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -13,6 +13,7 @@ import 'package:pot_g/app/modules/chat/presentation/bloc/pot_detail_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/pot_info_bloc.dart';
 import 'package:pot_g/app/modules/chat/presentation/bloc/taxi_app_cubit.dart';
 import 'package:pot_g/app/modules/chat/presentation/extensions/pot_action_exception.dart';
+import 'package:pot_g/app/modules/chat/presentation/extensions/pot_info_exception_extension.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/accounting_button.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_input.dart';
 import 'package:pot_g/app/modules/chat/presentation/widgets/chat_list.dart';
@@ -131,8 +132,10 @@ class ChatRoomPage extends StatelessWidget with LogPage {
         child: BlocBuilder<PotInfoBloc, PotInfoState>(
           builder: (context, state) {
             if (state.error != null) {
+              final error = state.error!;
               return ErrorCover(
-                message: state.error!,
+                message:
+                    '${error.err.getErrorMessage(context)} (${error.errorId})',
                 onRefresh: () {
                   context.read<PotInfoBloc>().add(
                     PotInfoEvent.init(_PotId(id: id)),

--- a/lib/app/modules/chat/presentation/pages/chat_room_page.dart
+++ b/lib/app/modules/chat/presentation/pages/chat_room_page.dart
@@ -80,7 +80,9 @@ class ChatRoomPage extends StatelessWidget with LogPage {
           BlocListener<ChatBloc, ChatState>(
             listenWhen: (prev, curr) =>
                 prev.error != curr.error && curr.error != null,
-            listener: (context, state) => context.showToast(state.error!),
+            listener: (context, state) => context.showToast(
+              '${context.t.common.unknown_error} (${state.error!})',
+            ),
           ),
           BlocListener<PotActionBloc, PotActionState>(
             listener: (context, state) {

--- a/lib/app/modules/core/presentation/bloc/app_version_bloc.dart
+++ b/lib/app/modules/core/presentation/bloc/app_version_bloc.dart
@@ -26,8 +26,7 @@ class AppVersionBloc extends Bloc<AppVersionEvent, AppVersionState> {
       final versionInfo = await _appVersionRepository.getVersionInfo();
       emit(AppVersionState.data(versionInfo));
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(AppVersionState.error(e.toString()));
+      emit(AppVersionState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -41,7 +40,7 @@ sealed class AppVersionEvent with _$AppVersionEvent {
 sealed class AppVersionState with _$AppVersionState {
   const factory AppVersionState.initial() = _Initial;
   const factory AppVersionState.loading() = _Loading;
-  const factory AppVersionState.error(String message) = AppVersionStateError;
+  const factory AppVersionState.error(String errorId) = AppVersionStateError;
   const factory AppVersionState.data(VersionInfoEntity versionInfo) =
       AppVersionStateData;
 }

--- a/lib/app/modules/core/presentation/bloc/route_list_bloc.dart
+++ b/lib/app/modules/core/presentation/bloc/route_list_bloc.dart
@@ -21,8 +21,7 @@ class RouteListBloc extends Bloc<RouteListEvent, RouteListState> {
       final routes = await _repository.getRouteList();
       emit(RouteListState.loaded(routes));
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(RouteListState.error(e.toString()));
+      emit(RouteListState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -39,7 +38,7 @@ sealed class RouteListState with _$RouteListState {
   const factory RouteListState.initial() = _Initial;
   const factory RouteListState.loading() = _Loading;
   const factory RouteListState.loaded(List<RouteEntity> routes) = _Loaded;
-  const factory RouteListState.error(String message) = _Error;
+  const factory RouteListState.error(String errorId) = _Error;
 
   List<RouteEntity> get routes => switch (this) {
     _Loaded(:final routes) => routes,

--- a/lib/app/modules/core/presentation/widgets/update_listener.dart
+++ b/lib/app/modules/core/presentation/widgets/update_listener.dart
@@ -74,11 +74,11 @@ class UpdateListener extends StatelessWidget {
               if (result == OkCancelResult.ok) await _launchStore();
             }
             break;
-          case AppVersionStateError(:final message):
+          case AppVersionStateError(:final errorId):
             await showOkAlertDialog(
               context: navigatorContext,
               title: 'App version error',
-              message: message,
+              message: '${context.t.common.unknown_error} ($errorId)',
             );
             break;
           default:

--- a/lib/app/modules/core/presentation/widgets/update_listener.dart
+++ b/lib/app/modules/core/presentation/widgets/update_listener.dart
@@ -77,7 +77,7 @@ class UpdateListener extends StatelessWidget {
           case AppVersionStateError(:final errorId):
             await showOkAlertDialog(
               context: navigatorContext,
-              title: 'App version error',
+              title: context.t.update.error.title,
               message: '${context.t.common.unknown_error} ($errorId)',
             );
             break;

--- a/lib/app/modules/list/presentation/bloc/pot_overview_bloc.dart
+++ b/lib/app/modules/list/presentation/bloc/pot_overview_bloc.dart
@@ -21,8 +21,7 @@ class PotOverviewBloc extends Bloc<PotOverviewEvent, PotOverviewState> {
       final overview = await _repository.getPotOverview(event.potId);
       emit(PotOverviewState.loaded(overview));
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(PotOverviewState.error(e.toString()));
+      emit(PotOverviewState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -37,14 +36,14 @@ sealed class PotOverviewState with _$PotOverviewState {
   const PotOverviewState._();
   const factory PotOverviewState.loading() = _Loading;
   const factory PotOverviewState.loaded(PotOverviewEntity overview) = _Loaded;
-  const factory PotOverviewState.error(String message) = _Error;
+  const factory PotOverviewState.error(String errorId) = _Error;
 
   PotOverviewEntity? get overview => switch (this) {
     _Loaded(:final overview) => overview,
     _ => null,
   };
-  String? get error => switch (this) {
-    _Error(:final message) => message,
+  String? get errorId => switch (this) {
+    _Error(:final errorId) => errorId,
     _ => null,
   };
 }

--- a/lib/app/modules/socket/presentation/bloc/socket_auth_bloc.dart
+++ b/lib/app/modules/socket/presentation/bloc/socket_auth_bloc.dart
@@ -61,8 +61,7 @@ class SocketAuthBloc extends Bloc<SocketAuthEvent, SocketAuthState> {
     try {
       await _socket.connect();
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(SocketAuthState.error(e.toString()));
+      emit(SocketAuthState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -85,7 +84,7 @@ sealed class SocketAuthState with _$SocketAuthState {
   const factory SocketAuthState.disconnected() = SocketDisconnected;
   const factory SocketAuthState.failed() = SocketFailed;
   const factory SocketAuthState.authorized() = _Authorized;
-  const factory SocketAuthState.error(String message) = SocketError;
+  const factory SocketAuthState.error(String errorId) = SocketError;
 
   bool get isConnected => switch (this) {
     SocketConnected() => true,

--- a/lib/app/modules/user/presentation/blocs/bank_list_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/bank_list_bloc.dart
@@ -21,8 +21,7 @@ class BankListBloc extends Bloc<BankListEvent, BankListState> {
       final banks = await _accountingRepository.getBankList();
       emit(BankListState.loaded(banks));
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(BankListState.error(e.toString()));
+      emit(BankListState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -39,7 +38,7 @@ sealed class BankListState with _$BankListState {
   const factory BankListState.initial() = _Initial;
   const factory BankListState.loading() = _Loading;
   const factory BankListState.loaded(List<BankEntity> banks) = _Loaded;
-  const factory BankListState.error(String message) = _Error;
+  const factory BankListState.error(String errorId) = _Error;
 
   List<BankEntity> get banks => switch (this) {
     _Loaded(:final banks) => banks,

--- a/lib/app/modules/user/presentation/blocs/consent_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/consent_bloc.dart
@@ -21,8 +21,7 @@ class ConsentBloc extends Bloc<ConsentEvent, ConsentState> {
       await _repository.updateConsent(event.terms);
       emit(const ConsentState.loaded());
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(ConsentState.error(e.toString()));
+      emit(ConsentState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -37,5 +36,5 @@ sealed class ConsentState with _$ConsentState {
   const factory ConsentState.initial() = _Initial;
   const factory ConsentState.loading() = _Loading;
   const factory ConsentState.loaded() = _Loaded;
-  const factory ConsentState.error(String message) = _Error;
+  const factory ConsentState.error(String errorId) = _Error;
 }

--- a/lib/app/modules/user/presentation/blocs/push_setting_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/push_setting_bloc.dart
@@ -32,8 +32,7 @@ class PushSettingBloc extends Bloc<PushSettingEvent, PushSettingState> {
         ),
       );
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(PushSettingState.error(e.toString()));
+      emit(PushSettingState.error(L.e(e, stackTrace)));
     }
   }
 
@@ -61,8 +60,7 @@ class PushSettingBloc extends Bloc<PushSettingEvent, PushSettingState> {
         );
       }
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(PushSettingState.error(e.toString()));
+      emit(PushSettingState.error(L.e(e, stackTrace)));
     }
   }
 
@@ -110,5 +108,5 @@ sealed class PushSettingState with _$PushSettingState {
     PushSettingEntity pushSetting, {
     @Default(true) bool isOsNotificationEnabled,
   }) = _Loaded;
-  const factory PushSettingState.error(String message) = _Error;
+  const factory PushSettingState.error(String errorId) = _Error;
 }

--- a/lib/app/modules/user/presentation/blocs/set_bank_account_bloc.dart
+++ b/lib/app/modules/user/presentation/blocs/set_bank_account_bloc.dart
@@ -24,8 +24,7 @@ class SetBankAccountBloc
       await _repository.setAccounting(event.bank, event.accountNumber);
       emit(const SetBankAccountState.success());
     } catch (e, stackTrace) {
-      L.e(e, stackTrace);
-      emit(SetBankAccountState.error(e.toString()));
+      emit(SetBankAccountState.error(L.e(e, stackTrace)));
     }
   }
 }
@@ -42,14 +41,14 @@ sealed class SetBankAccountState with _$SetBankAccountState {
   const factory SetBankAccountState.initial() = _Initial;
   const factory SetBankAccountState.loading() = _Loading;
   const factory SetBankAccountState.success() = _Success;
-  const factory SetBankAccountState.error(String message) = _Error;
+  const factory SetBankAccountState.error(String errorId) = _Error;
 
   bool get isSuccess => switch (this) {
     _Success() => true,
     _ => false,
   };
-  String? get errorMessage => switch (this) {
-    _Error(:final message) => message,
+  String? get errorId => switch (this) {
+    _Error(:final errorId) => errorId,
     _ => null,
   };
 }

--- a/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
+++ b/lib/app/modules/user/presentation/pages/account_number_settings_page.dart
@@ -400,8 +400,10 @@ class _BankNumberState extends State<_BankNumber> {
             context.read<AuthBloc>().add(AuthEvent.update());
             context.router.pop();
           }
-          if (state.errorMessage != null) {
-            context.showToast(state.errorMessage!);
+          if (state.errorId != null) {
+            context.showToast(
+              '${context.t.common.unknown_error} (${state.errorId!})',
+            );
           }
         },
         child: Column(

--- a/lib/app/modules/user/presentation/pages/consent_page.dart
+++ b/lib/app/modules/user/presentation/pages/consent_page.dart
@@ -43,7 +43,9 @@ class ConsentPage extends StatelessWidget with LogPage {
           BlocListener<ConsentBloc, ConsentState>(
             listener: (context, state) {
               state.mapOrNull(
-                error: (e) => context.showToast(e.message),
+                error: (e) => context.showToast(
+                  '${context.t.common.unknown_error} (${e.errorId})',
+                ),
                 loaded: (_) {
                   final user = context.read<AuthBloc>().state.user;
                   if (user == null) return;

--- a/lib/app/modules/user/presentation/pages/notification_setting_page.dart
+++ b/lib/app/modules/user/presentation/pages/notification_setting_page.dart
@@ -157,7 +157,11 @@ class _NotificationSettingPageState extends State<_NotificationSettingPage>
                   ],
                 );
               },
-              error: (e) => Center(child: Text('Error: ${e.message}')),
+              error: (e) => Center(
+                child: Text(
+                  '${context.t.common.unknown_error} (${e.errorId})',
+                ),
+              ),
             );
           },
         ),


### PR DESCRIPTION
- API 실패나 예외 발생 시 `e.toString()` 같은 날것의 에러 메시지가 화면에 표시되는 문제가 있었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 로딩 오류(network/알 수 없음) 및 앱 버전 오류에 대한 다국어 메시지가 추가되었습니다.
* **버그 수정 / 개선**
  * 여러 화면의 오류 표시가 일관된 현지화된 메시지(unknown_error + 오류 ID)로 개선되어 사용자에게 보다 명확한 안내를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->